### PR TITLE
feat: core-185 add action to notify slack about release job status

### DIFF
--- a/.github/actions/slack-release-notification/README.md
+++ b/.github/actions/slack-release-notification/README.md
@@ -1,0 +1,44 @@
+# Slack Release Notification Action
+
+This action sends Slack notifications based on job status for release updates. It automatically detects success/failure states and sends appropriate messages to your Slack channel with visual indicators (✅ for success, ❌ for failure). Works correctly even when used with `if: always()`.
+
+## Usage
+
+```yaml
+- name: Notify Slack Release Status
+  if: always() # This is important to ensure the action runs always regardless of job status
+  uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+  with:
+    webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+    success-description: "This message will be shown in slack when the job is successful"
+    failure-description: "This message will be shown in slack when the job fails"
+    tag: ${{ env.TAG }}
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `webhook-url` | Slack webhook URL (pulled from odigos secrets in ci) | Yes | - |
+| `success-description` | Description message for successful releases | Yes | "Release completed successfully" |
+| `failure-description` | Description message for failed releases | Yes | "Release failed" |
+| `tag` | Release tag | No | - |
+
+## Slack Message Format
+
+### Success Message
+```json
+{
+  "description": "✅ Your success message",
+  "tag": "v1.0.0"
+}
+```
+
+### Failure Message
+```json
+{
+  "link": "https://github.com/owner/repo/actions/runs/123456789",
+  "description": "❌ Your failure message",
+  "tag": "v1.0.0"
+}
+```

--- a/.github/actions/slack-release-notification/action.yml
+++ b/.github/actions/slack-release-notification/action.yml
@@ -1,0 +1,49 @@
+name: 'Slack Release Notification'
+description: 'Send Slack notifications based on job status for release updates'
+
+inputs:
+  webhook-url:
+    description: 'Slack webhook URL'
+    required: true
+  success-description:
+    description: 'Description message for successful release step notification'
+    required: true
+  failure-description:
+    description: 'Description message for failed release step notification'
+    required: true
+  tag:
+    description: 'Release tag'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine Job Status and Notify Slack
+      shell: bash
+      run: |
+        # Check if any previous step in the job failed
+        if [ "${{ job.status }}" = "success" ]; then
+          echo "Job succeeded, sending success notification"
+          PAYLOAD='{
+            "description": "✅ ${{ inputs.success-description }}",
+            "tag": "${{ inputs.tag }}"
+          }'
+          echo "Success payload: $PAYLOAD"
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            ${{ inputs.webhook-url }}
+        else
+          echo "Job failed or was cancelled, sending failure notification"
+          REPO="${{ github.repository }}"
+          RUN_ID="${{ github.run_id }}"
+          
+          PAYLOAD="{
+            \"link\": \"https://github.com/$REPO/actions/runs/$RUN_ID\",
+            \"description\": \"❌ ${{ inputs.failure-description }}\",
+            \"tag\": \"${{ inputs.tag }}\"
+          }"
+          echo "Failure payload: $PAYLOAD"
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            ${{ inputs.webhook-url }}
+        fi


### PR DESCRIPTION
fixes: CORE-185

new action to publish messages to slack during release processes.

it can be consumed by ci workflows in various repos related to the release, making the workflow code simpler, cleaner, and consistent