### PR TITLE
fix: backtick in action input is interpreted by bash

### DIFF
--- a/.github/actions/slack-release-notification/action.yml
+++ b/.github/actions/slack-release-notification/action.yml
@@ -21,29 +21,28 @@ runs:
     - name: Determine Job Status and Notify Slack
       shell: bash
       run: |
-        # Check if any previous step in the job failed
         if [ "${{ job.status }}" = "success" ]; then
           echo "Job succeeded, sending success notification"
           PAYLOAD='{
-            "description": "✅ ${{ inputs.success-description }}",
-            "tag": "${{ inputs.tag }}"
+            "description": "✅ '"${{ inputs.success-description }}"'",
+            "tag": "'"${{ inputs.tag }}"'"
           }'
           echo "Success payload: $PAYLOAD"
           curl -X POST -H 'Content-type: application/json' \
             --data "$PAYLOAD" \
-            ${{ inputs.webhook-url }}
+            "${{ inputs.webhook-url }}"
         else
           echo "Job failed or was cancelled, sending failure notification"
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.run_id }}"
-          
-          PAYLOAD="{
-            \"link\": \"https://github.com/$REPO/actions/runs/$RUN_ID\",
-            \"description\": \"❌ ${{ inputs.failure-description }}\",
-            \"tag\": \"${{ inputs.tag }}\"
-          }"
+
+          PAYLOAD='{
+            "link": "https://github.com/'"$REPO"'/actions/runs/'"$RUN_ID"'",
+            "description": "❌ '"${{ inputs.failure-description }}"'",
+            "tag": "'"${{ inputs.tag }}"'"
+          }'
           echo "Failure payload: $PAYLOAD"
           curl -X POST -H 'Content-type: application/json' \
             --data "$PAYLOAD" \
-            ${{ inputs.webhook-url }}
+            "${{ inputs.webhook-url }}"
         fi

--- a/.github/actions/slack-release-notification/action.yml
+++ b/.github/actions/slack-release-notification/action.yml
@@ -36,11 +36,12 @@ runs:
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.run_id }}"
 
-          PAYLOAD='{
-            "link": "https://github.com/'"$REPO"'/actions/runs/'"$RUN_ID"'",
-            "description": "❌ '"${{ inputs.failure-description }}"'",
-            "tag": "'"${{ inputs.tag }}"'"
-          }'
+          PAYLOAD=$(jq -n \
+            --arg link "https://github.com/$REPO/actions/runs/$RUN_ID" \
+            --arg desc "❌ ${{ inputs.failure-description }}" \
+            --arg tag "${{ inputs.tag }}" \
+            '{link: $link, description: $desc, tag: $tag}')
+
           echo "Failure payload: $PAYLOAD"
           curl -X POST -H 'Content-type: application/json' \
             --data "$PAYLOAD" \


### PR DESCRIPTION
fixes: CORE-171

fix a bug in the `slack-release-notification` action:

```
What happened

You used backticks (`odigos-enterprise`) inside a double-quoted string.

In Bash, backticks mean command substitution.
So Bash tried to execute the command odigos-enterprise, which doesn’t exist → command not found.
```

Since we were building the payload content in bash, it got confused by the backticks. Now we use jq to build the payload json which works good (reproduced it and verified the fix in a test repo)
