### PR TITLE
fix: pass previous_tag_name to GitHub release notes API

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      current_version: ${{ steps.calc.outputs.current_version }}
       new_version: ${{ steps.calc.outputs.new_version }}
       create_branch: ${{ steps.calc.outputs.create_branch }}
       release_branch: ${{ steps.calc.outputs.release_branch }}
@@ -101,6 +102,7 @@ jobs:
           base_branch: ${{ needs.calculate.outputs.base_branch }}
           sts_identity: tag-releaser
           new_version: ${{ needs.calculate.outputs.new_version }}
+          previous_version: ${{ needs.calculate.outputs.current_version }}
           create_branch: ${{ needs.calculate.outputs.create_branch }}
           release_branch: ${{ needs.calculate.outputs.release_branch }}
           actor: ${{ github.actor }}

--- a/tag-and-release/README.md
+++ b/tag-and-release/README.md
@@ -200,6 +200,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      current_version: ${{ steps.calc.outputs.current_version }}
       new_version:    ${{ steps.calc.outputs.new_version }}
       create_branch:  ${{ steps.calc.outputs.create_branch }}
       release_branch: ${{ steps.calc.outputs.release_branch }}
@@ -249,9 +250,10 @@ jobs:
           bump: ${{ inputs.bump }}
           base_branch: ${{ inputs.base_branch }}
           sts_identity: your-identity
-          new_version:    ${{ needs.calculate.outputs.new_version }}
-          create_branch:  ${{ needs.calculate.outputs.create_branch }}
-          release_branch: ${{ needs.calculate.outputs.release_branch }}
+          new_version:      ${{ needs.calculate.outputs.new_version }}
+          previous_version: ${{ needs.calculate.outputs.current_version }}
+          create_branch:    ${{ needs.calculate.outputs.create_branch }}
+          release_branch:   ${{ needs.calculate.outputs.release_branch }}
           actor:   ${{ github.actor }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 ```
@@ -270,6 +272,7 @@ jobs:
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `new_version` | ✅ | — | Version to tag (from `calculate` outputs) |
+| `previous_version` | — | `""` | Previous version for release notes (from `calculate` outputs `current_version`) |
 | `bump` | ✅ | — | Original bump type (recorded in tag message) |
 | `base_branch` | ✅ | — | Branch being tagged (recorded in tag message) |
 | `create_branch` | — | `false` | Whether to create a release branch |

--- a/tag-and-release/action.yml
+++ b/tag-and-release/action.yml
@@ -37,6 +37,10 @@ inputs:
   new_version:
     description: "The version string to tag (e.g. v1.3.0). Output of the calculate phase."
     required: false
+  previous_version:
+    description: "The previous version tag for release notes (e.g. v1.2.0). Output of the calculate phase (current_version)."
+    required: false
+    default: ""
   create_branch:
     description: "'true' if a new release branch should be created"
     required: false
@@ -275,14 +279,20 @@ runs:
       env:
         GH_TOKEN: ${{ steps.sts.outputs.GH_TOKEN }}
         NEW_VERSION: ${{ inputs.new_version }}
+        PREVIOUS_VERSION: ${{ inputs.previous_version }}
       run: |
         PRERELEASE_FLAG=""
         if [[ "${NEW_VERSION}" == *"-pre."* || "${NEW_VERSION}" == *"-rc."* ]]; then
           PRERELEASE_FLAG="--prerelease"
         fi
 
+        GENERATE_NOTES_ARGS=(-f tag_name="${NEW_VERSION}")
+        if [[ -n "${PREVIOUS_VERSION}" ]]; then
+          GENERATE_NOTES_ARGS+=(-f previous_tag_name="${PREVIOUS_VERSION}")
+        fi
+
         NOTES=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-          -f tag_name="${NEW_VERSION}" \
+          "${GENERATE_NOTES_ARGS[@]}" \
           --jq '.body')
 
         MAX=124000


### PR DESCRIPTION
## Problem

The `Create GitHub release` step calls GitHub's `generate-notes` API with only `tag_name`, omitting the `previous_tag_name` parameter. GitHub's auto-detection of the previous release picks the wrong tag, causing release notes to span too many versions.

**Example:** Release [v1.2.0](https://github.com/odigos-io/enterprise-go-instrumentation/releases/tag/v1.2.0) included notes all the way back to `v1.0.0-pre.0` instead of just to `v1.1.0`.

The calculate phase correctly determines `current_version` (the previous tag) and outputs it, but the tag phase never received it as an input.

## Fix

- Add `previous_version` input to the tag phase of the `tag-and-release` action
- Pass it as `previous_tag_name` to the `gh api repos/.../releases/generate-notes` call
- Update the bundled workflow and README example to forward `current_version` → `previous_version`

The new input is optional with an empty default, so existing callers that don't pass it continue to work (falling back to GitHub's auto-detection). Callers should be updated to pass `previous_version` for correct release notes.

## Files changed

| File | Change |
|---|---|
| `tag-and-release/action.yml` | Add `previous_version` input; pass it to generate-notes API |
| `.github/workflows/tag-and-release.yml` | Forward `current_version` output as `previous_version` input |
| `tag-and-release/README.md` | Document new input; update example workflow |

Fixes RUN-568