### PR TITLE
Revert "fix(tag-and-release): harden action against script injection and simplify" RUN-00

### DIFF
--- a/tag-and-release/action.yml
+++ b/tag-and-release/action.yml
@@ -4,88 +4,82 @@ description: |
 
   Phase 1 — operation: calculate
     Computes the next version from git tag history and writes the release preview
-    to the GitHub Actions job summary.
+    to the GitHub Actions job summary. The repo must already be checked out with
+    full history and tags (fetch-depth: 0, fetch-tags: true).
 
   Phase 2 — operation: tag
     Creates the annotated git tag, pushes it, creates the GitHub release, and
-    (when required) creates the release branch. Uses a semver-aware release notes
-    generator to ensure correct diff ranges for stable, patch, and RC releases.
+    (when required) creates the release branch. The repo must be checked out with
+    persist-credentials: false so that STS handles authentication. The calling job
+    must have id-token: write permission for the STS OIDC exchange.
 
 inputs:
   operation:
     description: "'calculate' to compute the next version; 'tag' to create the tag/release/branch"
     required: true
 
+  # ── calculate inputs ────────────────────────────────────────────────────────
   bump:
     description: "Bump type: patch | minor | major | pre-minor | pre-major | rc-minor | rc-major"
     required: false
-
   base_branch:
     description: |
       The branch being tagged.
-      Accepts shorthand:
+      Release branches can be written in short form — all of the
+      following are equivalent:
         releases/v1.3.x   (canonical)
         v1.3.x
-        1.3.x
+        1.3.x             (shortest)
+      Default branch (e.g. main) must be given as-is.
     required: false
 
+  # ── tag inputs ──────────────────────────────────────────────────────────────
   new_version:
-    description: "Version to tag (e.g. v1.3.0)"
+    description: "The version string to tag (e.g. v1.3.0). Output of the calculate phase."
     required: false
-
+  previous_version:
+    description: "The previous version tag for release notes (e.g. v1.2.0). Output of the calculate phase (current_version)."
+    required: false
+    default: ""
   create_branch:
     description: "'true' if a new release branch should be created"
     required: false
     default: "false"
-
   release_branch:
-    description: "Release branch name (e.g. releases/v1.3.x)"
+    description: "Release branch name, e.g. releases/1.3.x"
     required: false
     default: ""
-
   actor:
-    description: "GitHub actor (github.actor)"
+    description: "GitHub actor (github.actor) — recorded in the tag message"
     required: false
-
   run_url:
-    description: "URL of triggering workflow run"
+    description: "URL of the triggering Actions run — recorded in the tag message"
     required: false
-
   sts_identity:
-    description: "STS identity for authentication"
+    description: "STS identity to request"
     required: false
     default: ""
 
 outputs:
   current_version:
-    description: "Most recent version tag reachable from HEAD"
+    description: "Most recent version tag reachable from HEAD (calculate phase)"
     value: ${{ steps.calc.outputs.current_version }}
-
   new_version:
-    description: "New version calculated"
+    description: "The newly calculated version (calculate phase)"
     value: ${{ steps.calc.outputs.new_version }}
-
   create_branch:
-    description: "Whether a release branch should be created"
+    description: "'true' if a new release branch should be created (calculate phase)"
     value: ${{ steps.calc.outputs.create_branch }}
-
   release_branch:
-    description: "Release branch name"
+    description: "Release branch name (calculate phase)"
     value: ${{ steps.calc.outputs.release_branch }}
 
 runs:
   using: composite
   steps:
 
-    - name: Validate operation
-      shell: bash
-      env:
-        OPERATION: ${{ inputs.operation }}
-      run: |
-        if [[ "$OPERATION" != "calculate" && "$OPERATION" != "tag" ]]; then
-          echo "::error::Invalid operation '$OPERATION'. Must be 'calculate' or 'tag'."
-          exit 1
-        fi
+    # ── NORMALIZE base_branch input ────────────────────────────────────────────
+    # Accepts shorthand: "1.3.x" or "v1.3.x" → "releases/v1.3.x"
 
     - name: Normalize base_branch
       id: normalize
@@ -94,11 +88,15 @@ runs:
         BASE_BRANCH: ${{ inputs.base_branch }}
       run: |
         b="${BASE_BRANCH}"
+        # Strip "releases/" prefix if present
         b="${b#releases/}"
+        # If it now looks like N.N.x (with or without leading v), normalise
         if [[ "$b" =~ ^v?[0-9]+\.[0-9]+\.x$ ]]; then
           b="releases/v${b#v}"
         fi
         echo "base_branch=${b}" >> "$GITHUB_OUTPUT"
+
+    # ── CALCULATE PHASE ────────────────────────────────────────────────────────
 
     - name: Validate branch and bump combination
       if: ${{ inputs.operation == 'calculate' }}
@@ -110,9 +108,21 @@ runs:
       run: |
         if [[ "${BASE_BRANCH}" == "${DEFAULT_BRANCH}" ]]; then
           if [[ "${BUMP}" == "patch" ]]; then
-            echo "::error::patch not allowed on default branch"
+            echo "::error::patch is not allowed on the default branch (${DEFAULT_BRANCH}); use a release branch (releases/vX.Y.x)"
             exit 1
           fi
+        elif [[ "${BASE_BRANCH}" =~ ^releases/v[0-9]+\.[0-9]+\.x$ ]]; then
+          # The release branch must already exist. To start a new pre-release
+          # series (which creates the branch), run from the default branch.
+          if ! git ls-remote --exit-code --heads origin "${BASE_BRANCH}" \
+               >/dev/null 2>&1; then
+            echo "::error::release branch '${BASE_BRANCH}' does not exist;" \
+                 "to start a new pre-release series, run from ${DEFAULT_BRANCH}"
+            exit 1
+          fi
+        else
+          echo "::error::invalid base_branch '${BASE_BRANCH}': must be the default branch (${DEFAULT_BRANCH}) or a release branch (releases/vX.Y.x, vX.Y.x, or X.Y.x)"
+          exit 1
         fi
 
     - name: Calculate new version
@@ -124,7 +134,52 @@ runs:
         BASE_BRANCH: ${{ steps.normalize.outputs.base_branch }}
       run: node "${{ github.action_path }}/calculate.js"
 
-    # ---------------- TAG PHASE ----------------
+    - name: Write release preview summary
+      if: ${{ inputs.operation == 'calculate' }}
+      shell: bash
+      env:
+        BASE_BRANCH: ${{ steps.normalize.outputs.base_branch }}
+        BUMP: ${{ inputs.bump }}
+        CURRENT_VERSION: ${{ steps.calc.outputs.current_version }}
+        NEW_VERSION: ${{ steps.calc.outputs.new_version }}
+        CREATE_BRANCH: ${{ steps.calc.outputs.create_branch }}
+        RELEASE_BRANCH: ${{ steps.calc.outputs.release_branch }}
+      run: |
+        {
+          echo "### Release Preview"
+          echo ""
+          echo "| Field | Value |"
+          echo "|---|---|"
+          echo "| Base branch | \`${BASE_BRANCH}\` |"
+          echo "| Bump type | \`${BUMP}\` |"
+          echo "| Current version | \`${CURRENT_VERSION}\` |"
+          echo "| **New version** | \`${NEW_VERSION}\` |"
+          if [[ "${CREATE_BRANCH}" == "true" ]]; then
+            echo "| Release branch | \`${RELEASE_BRANCH}\` *(will be created)* |"
+          fi
+          echo ""
+          echo "#### Commits in this release"
+          echo ""
+          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          _log_commits() {
+            git log "$@" --format="%H %s" --no-decorate \
+              | while IFS= read -r line; do
+                  sha="${line%% *}"
+                  msg="${line#* }"
+                  short="${sha:0:7}"
+                  echo "- [\`${short}\`](${REPO_URL}/commit/${sha}) ${msg}"
+                done
+          }
+          if git rev-parse "${CURRENT_VERSION}" >/dev/null 2>&1; then
+            _log_commits "${CURRENT_VERSION}..HEAD"
+          else
+            _log_commits HEAD
+          fi
+          echo ""
+          echo "> Approve the **release-gate** environment below to proceed."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    # ── TAG PHASE ──────────────────────────────────────────────────────────────
 
     - name: Get STS token
       id: sts
@@ -134,45 +189,89 @@ runs:
         scope: ${{ github.repository }}
         identity: ${{ inputs.sts_identity }}
 
-    - name: Configure git
+    - name: Configure git identity
       if: ${{ inputs.operation == 'tag' }}
       shell: bash
       run: |
-        git config user.name "ci-core[bot]"
+        git config user.name  "ci-core[bot]"
         git config user.email "ci-core-bot@odigos.io"
 
-    - name: Create release branch (if needed)
+    - name: Verify HEAD matches base branch
+      if: ${{ inputs.operation == 'tag' }}
+      shell: bash
+      env:
+        BASE_BRANCH: ${{ steps.normalize.outputs.base_branch }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        LOCAL_SHA=$(git rev-parse HEAD)
+        REMOTE_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
+        if [[ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]]; then
+          echo "::error::HEAD (${LOCAL_SHA}) does not match origin/${BASE_BRANCH} (${REMOTE_SHA}); aborting to avoid tagging the wrong commit"
+          exit 1
+        fi
+        # For release branches: the tagged commit must not be reachable from the
+        # default branch, otherwise the patch tag would effectively live on main too.
+        if [[ "${BASE_BRANCH}" =~ ^releases/v[0-9]+\.[0-9]+\.x$ ]]; then
+          if git merge-base --is-ancestor HEAD "origin/${DEFAULT_BRANCH}"; then
+            echo "::error::HEAD is reachable from ${DEFAULT_BRANCH}; patch tags must be on commits exclusive to ${BASE_BRANCH} (has anything been committed to the release branch yet?)"
+            exit 1
+          fi
+        fi
+
+    - name: Fail if tag already exists
+      if: ${{ inputs.operation == 'tag' }}
+      shell: bash
+      env:
+        NEW_VERSION: ${{ inputs.new_version }}
+      run: |
+        if git rev-parse "${NEW_VERSION}" >/dev/null 2>&1; then
+          echo "::error::Tag ${NEW_VERSION} already exists"; exit 1
+        fi
+
+    # When a new release branch is needed, create it and push an empty "begin"
+    # commit BEFORE tagging. This guarantees the initial version tag lands on a
+    # commit that is exclusive to the release branch (not reachable from main),
+    # satisfying the same invariant that patch tags must hold.
+    - name: Create release branch with begin commit
       if: ${{ inputs.operation == 'tag' && inputs.create_branch == 'true' }}
       shell: bash
       env:
         RELEASE_BRANCH: ${{ inputs.release_branch }}
         NEW_VERSION: ${{ inputs.new_version }}
       run: |
-        if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
-          echo "Branch exists"
+        if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+          echo "Branch ${RELEASE_BRANCH} already exists; skipping."
         else
-          git checkout -b "$RELEASE_BRANCH"
-          git commit --allow-empty -m "chore: begin $RELEASE_BRANCH ($NEW_VERSION)"
-          git push origin "$RELEASE_BRANCH"
+          git checkout -b "${RELEASE_BRANCH}"
+          git commit --allow-empty -m "chore: begin ${RELEASE_BRANCH} (${NEW_VERSION})"
+          git push origin "${RELEASE_BRANCH}"
         fi
 
-    - name: Create tag
+    - name: Create & push tag
       if: ${{ inputs.operation == 'tag' }}
       shell: bash
       env:
         NEW_VERSION: ${{ inputs.new_version }}
+        BUMP: ${{ inputs.bump }}
+        BASE_BRANCH: ${{ steps.normalize.outputs.base_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        CREATE_BRANCH: ${{ inputs.create_branch }}
+        ACTOR: ${{ inputs.actor }}
+        RUN_URL: ${{ inputs.run_url }}
       run: |
-        git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
-        git push origin "$NEW_VERSION"
-
-    - name: Generate release notes (semver-aware)
-      if: ${{ inputs.operation == 'tag' }}
-      id: notes
-      uses: odigos-io/ci-core/generate-release-notes@main
-      with:
-        tag: ${{ inputs.new_version }}
-        release-branch: ${{ inputs.release_branch }}
-        sts_identity: ${{ inputs.sts_identity }}
+        # Record the branch the tag actually lands on (release branch when newly created)
+        BRANCH_LABEL="${BASE_BRANCH}"
+        if [[ "${CREATE_BRANCH}" == "true" ]]; then
+          BRANCH_LABEL="${RELEASE_BRANCH}"
+        fi
+        git tag -a "${NEW_VERSION}" -m "$(printf \
+          'Release %s\n\nbump:    %s\nbranch:  %s\nactor:   %s\nrun:     %s' \
+          "${NEW_VERSION}" \
+          "${BUMP}" \
+          "${BRANCH_LABEL}" \
+          "${ACTOR}" \
+          "${RUN_URL}")"
+        git push origin "${NEW_VERSION}"
 
     - name: Create GitHub release
       if: ${{ inputs.operation == 'tag' }}
@@ -180,27 +279,30 @@ runs:
       env:
         GH_TOKEN: ${{ steps.sts.outputs.GH_TOKEN }}
         NEW_VERSION: ${{ inputs.new_version }}
-        NOTES: ${{ steps.notes.outputs.release_notes }}
+        PREVIOUS_VERSION: ${{ inputs.previous_version }}
       run: |
-        # Fail fast if notes are missing
-        if [[ -z "$NOTES" ]]; then
-          echo "::error::release notes are empty"
-          exit 1
-        fi
-
         PRERELEASE_FLAG=""
         if [[ "${NEW_VERSION}" == *"-pre."* || "${NEW_VERSION}" == *"-rc."* ]]; then
           PRERELEASE_FLAG="--prerelease"
         fi
 
-        MAX=124000
-        if [ "${#NOTES}" -gt "$MAX" ]; then
-          NOTES="${NOTES:0:$MAX}"$'\n\n_Release notes truncated — see full artifact for details._'
+        GENERATE_NOTES_ARGS=(-f tag_name="${NEW_VERSION}")
+        if [[ -n "${PREVIOUS_VERSION}" ]]; then
+          GENERATE_NOTES_ARGS+=(-f previous_tag_name="${PREVIOUS_VERSION}")
         fi
 
-        echo "$NOTES" | gh release create "${NEW_VERSION}" \
+        NOTES=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+          "${GENERATE_NOTES_ARGS[@]}" \
+          --jq '.body')
+
+        MAX=124000
+        if [ "${#NOTES}" -gt "$MAX" ]; then
+          NOTES="${NOTES:0:$MAX}"$'\n\n_Release notes truncated — see full git history for details._'
+        fi
+
+        gh release create "${NEW_VERSION}" \
           --title "${NEW_VERSION}" \
-          --notes-file - \
+          --notes "$NOTES" \
           $PRERELEASE_FLAG
 
     - name: Write release complete summary


### PR DESCRIPTION
## Summary
- Reverts #80 which broke the release workflow for `ebpf-java-instrumentation`
- The `generate-release-notes` action introduced in #80 uses the k8s `release-notes` tool which calls `GET /repos/.../commits/{sha}/pulls` — this requires `pull_requests: read` on the STS token, which the `tag-releaser` identity does not have
- Restores the previous release notes generation that used GitHub's built-in `releases/generate-notes` API (only needs `contents: write`)

## Context
- Failed run: https://github.com/odigos-io/ebpf-java-instrumentation/actions/runs/23843604140/job/69506662242
- Error: `403 Resource not accessible by integration` on the commits/pulls endpoint