### PR TITLE
fix(sts): fail fast when id-token: write permission is missing

### DIFF
--- a/sts/fetch.js
+++ b/sts/fetch.js
@@ -33,6 +33,14 @@ async function run({
     throw new Error('one of "pairs" or "scope"+"identity" is required');
   }
 
+  // ── early check: id-token: write must be set ────────────────────────────────
+  if (!env.ACTIONS_ID_TOKEN_REQUEST_URL || !env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) {
+    throw new Error(
+      'GitHub Actions OIDC credentials are not available — ' +
+      'the calling workflow must include "permissions: id-token: write"',
+    );
+  }
+
   const pairsInput = hasPairs
     ? rawPairs
     : `${legacyScope}:${legacyIdentity}`;

--- a/sts/test.js
+++ b/sts/test.js
@@ -444,6 +444,30 @@ test('OUTPUT_GIT_CONFIG=false → git exec not called, no GIT_CONFIG_PATH output
 });
 
 // ---------------------------------------------------------------------------
+// Missing OIDC environment
+// ---------------------------------------------------------------------------
+
+test('missing ACTIONS_ID_TOKEN_REQUEST_URL → rejects with actionable message', async () => {
+  process.env.PAIRS = 'odigos-io/my-repo:my-identity';
+  delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+
+  await assert.rejects(
+    () => run({ fetchFn: mockFetch(), execFileSync: noopExec, env: process.env }),
+    /id-token: write/,
+  );
+});
+
+test('missing ACTIONS_ID_TOKEN_REQUEST_TOKEN → rejects with actionable message', async () => {
+  process.env.PAIRS = 'odigos-io/my-repo:my-identity';
+  delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+
+  await assert.rejects(
+    () => run({ fetchFn: mockFetch(), execFileSync: noopExec, env: process.env }),
+    /id-token: write/,
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Custom domain
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds an early safeguard in the STS action to check that both `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are set before any pair processing begins
- Provides a clear error message directing users to add `permissions: id-token: write` to their workflow
- Adds a new test case for the missing `ACTIONS_ID_TOKEN_REQUEST_TOKEN` scenario

## Test plan
- [x] All 28 existing + new tests pass (`node --test sts/test.js`)
- [x] Verify in a workflow without `id-token: write` that the action fails immediately with the expected message


fixes RUN-00