### PR TITLE
fix(tag-and-release): scope patch version to branch-reachable tags

### DIFF
--- a/tag-and-release/calculate.js
+++ b/tag-and-release/calculate.js
@@ -9,7 +9,7 @@
 // The repo must already be checked out with full history and tags
 // (fetch-depth: 0, fetch-tags: true) before this script runs.
 //
-// Version bump logic (based on the latest stable tag visible repo-wide):
+// Version bump logic (based on the latest stable tag; branch-scoped for patch):
 //
 //   major      v1.2.3        → v2.0.0         + creates releases/v2.0.x branch
 //   major      v2.0.0-pre.N  → v2.0.0           (promotes pre to stable; branch already exists)
@@ -199,8 +199,11 @@ function calculate({ execSync = defaultExecSync, env = process.env } = {}) {
         const latestAny = latest(scopedTags) ?? 'v0.0.0';
         const lav = parseVersion(latestAny);
         if (!lav.preType) {
-          // Latest is already stable — normal patch increment
-          newVersion = `v${major}.${minor}.${patch + 1}`;
+          // Latest is already stable — normal patch increment.
+          // Use the branch-scoped version (lav) instead of the global
+          // latest so we increment the correct series.
+          displayCurrent = latestAny;
+          newVersion = `v${lav.major}.${lav.minor}.${lav.patch + 1}`;
         } else {
           const baseVer = `v${lav.major}.${lav.minor}.${lav.patch}`;
           if (tagExists(baseVer)) {

--- a/tag-and-release/test.js
+++ b/tag-and-release/test.js
@@ -263,6 +263,20 @@ test('patch on release branch (stable) → normal increment', () => {
   assert.equal(r.newVersion, 'v1.3.1');
 });
 
+test('patch on release branch scopes to branch, ignores globally higher tags', () => {
+  // Repo has v0.0.14 on releases/v0.0.x and v0.1.0, v0.2.0, v0.3.0 on other
+  // branches. Only v0.0.14 is reachable from HEAD (releases/v0.0.x).
+  // The calculate step must produce v0.0.15, NOT v0.3.1.
+  const allTags    = ['v0.0.14', 'v0.1.0', 'v0.2.0', 'v0.3.0'];
+  const mergedTags = ['v0.0.14'];
+  const r = calculate({
+    execSync: makeExecSync(allTags, mergedTags),
+    env: { BUMP: 'patch', BASE_BRANCH: 'releases/v0.0.x' },
+  });
+  assert.equal(r.currentVersion, 'v0.0.14');
+  assert.equal(r.newVersion,     'v0.0.15');
+});
+
 test('patch on release branch (pre only, no stable base) → promotes to stable', () => {
   // releases/v1.3.x has v1.3.0-pre.1 but v1.3.0 stable not yet released
   const allTags    = ['v1.2.3', 'v1.3.0-pre.1'];


### PR DESCRIPTION
Fixes RUN-00
## Summary

- **Bug**: When running `patch` bump on a release branch (e.g. `releases/v0.0.x`), the calculate step picked the globally latest stable tag (e.g. `v0.3.0` from `main`) instead of the latest tag reachable from the release branch (`v0.0.14`), producing `v0.3.1` instead of `v0.0.15`.
- **Root cause**: The stable-patch path in `calculate.js` used `major`/`minor`/`patch` variables derived from `getAllStableTags()` (repo-wide `git tag --list`) rather than from the branch-scoped `latestAny` variable (derived from `git tag --merged HEAD`).
- **Fix**: Use the branch-scoped parsed version (`lav`) for the patch increment and set `displayCurrent` from the scoped tag. This is a two-line logic change. Backwards-compatible: on `main` (non-release branch), the existing global-tag path is unchanged.

## Test plan

- [x] Added regression test: `patch` on `releases/v0.0.x` with globally higher tags (`v0.1.0`, `v0.2.0`, `v0.3.0`) produces `v0.0.14 -> v0.0.15`
- [x] All 29 tests pass (28 existing + 1 new)
- [x] Verified no behavior change for non-release-branch paths (`main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)