### PR TITLE
ci: add major version config to cherry pick action

### DIFF
--- a/cherry-pick/README.md
+++ b/cherry-pick/README.md
@@ -23,7 +23,9 @@ Short forms are accepted and normalized to `v1.X`:
 cherry-pick: 1.3, 1.4
 ```
 
-The expected major version defaults to `1` (`major-version` input). Set `major-version: "2"` to accept `v2.3` / `2.3` instead.
+The expected major version defaults to `1` (`major-version` input). Set for example `major-version: "0"` to accept `v0.x` instead.
+
+Lines inside HTML comments (`<!-- ... -->`) are ignored, so PR templates can document the format without triggering backports.
 
 Invalid entries are skipped with a warning. If the line is missing or no valid versions remain, the workflow exits without creating PRs.
 

--- a/cherry-pick/README.md
+++ b/cherry-pick/README.md
@@ -23,6 +23,8 @@ Short forms are accepted and normalized to `v1.X`:
 cherry-pick: 1.3, 1.4
 ```
 
+The expected major version defaults to `1` (`major-version` input). Set `major-version: "2"` to accept `v2.3` / `2.3` instead.
+
 Invalid entries are skipped with a warning. If the line is missing or no valid versions remain, the workflow exits without creating PRs.
 
 ---
@@ -178,6 +180,7 @@ Workflow-level `permissions: read-all` is sufficient when jobs grant `id-token: 
 | `base-branch` | No | `main` | both |
 | `release-branch-prefix` | No | `releases/` | backport |
 | `release-branch-suffix` | No | `.0` | backport |
+| `major-version` | No | `1` | extract |
 | `cherry-pick-decision-identity` | No | `cherry-pick-decision` | extract |
 | `commit-sha` | No | `${{ github.sha }}` | extract |
 | `create-pr-identity` | No | `create-pr` | backport |

--- a/cherry-pick/action.yml
+++ b/cherry-pick/action.yml
@@ -1,7 +1,7 @@
 name: Cherry Pick
 description: |
   Backport merged PRs to release branches when the PR description contains
-  `cherry-pick: v1.X` (comma-separated versions).
+  `cherry-pick: v{major}.X` (comma-separated versions; major defaults to 1).
 
   - operation: extract — resolve the merged PR for a push commit and parse target versions.
   - operation: backport — cherry-pick one version onto its release branch and open a pull request.
@@ -28,6 +28,10 @@ inputs:
     description: Suffix after the version in release branch names (e.g. .0 for releases/v1.3.0).
     required: false
     default: ".0"
+  major-version:
+    description: Expected major version in cherry-pick lines (e.g. 1 for v1.3 or 0 for v0.8).
+    required: false
+    default: "1"
 
   # ── extract ─────────────────────────────────────────────────────────────────
   cherry-pick-decision-identity:
@@ -161,8 +165,11 @@ runs:
       id: parse_versions
       if: ${{ inputs.operation == 'extract' && steps.find_pr.outputs.has_pr == 'true' && steps.pr_files.outcome == 'success' }}
       shell: bash
+      env:
+        MAJOR_VERSION: ${{ inputs.major-version }}
       run: |
         set -euo pipefail
+        MAJOR="${MAJOR_VERSION:-1}"
         PR_BODY=$(cat .cherry-pick-workflow/pr_body.txt)
 
         CHERRY_PICK_LINE=$(echo "$PR_BODY" | grep -i "^cherry-pick:" || true)
@@ -179,14 +186,14 @@ runs:
         IFS=',' read -ra VERSION_ARRAY <<< "$VERSIONS_STR"
         for version in "${VERSION_ARRAY[@]}"; do
           version=$(printf '%s' "$version" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-          if [[ "$version" =~ ^1\.[0-9]+$ ]]; then
+          if [[ "$version" =~ ^${MAJOR}\.[0-9]+$ ]]; then
             version="v${version}"
           fi
-          if [[ "$version" =~ ^v1\.[0-9]+$ ]]; then
+          if [[ "$version" =~ ^v${MAJOR}\.[0-9]+$ ]]; then
             VALID_VERSIONS+=("\"$version\"")
             echo "Valid version found: $version"
           else
-            echo "Warning: Invalid version format '$version' (expected v1.X or 1.X)"
+            echo "Warning: Invalid version format '$version' (expected v${MAJOR}.X or ${MAJOR}.X)"
           fi
         done
 

--- a/cherry-pick/action.yml
+++ b/cherry-pick/action.yml
@@ -172,7 +172,10 @@ runs:
         MAJOR="${MAJOR_VERSION:-1}"
         PR_BODY=$(cat .cherry-pick-workflow/pr_body.txt)
 
-        CHERRY_PICK_LINE=$(echo "$PR_BODY" | grep -i "^cherry-pick:" || true)
+        # Strip HTML comments so template examples (e.g. <!-- cherry-pick: v0.6 -->) are ignored.
+        PR_BODY=$(printf '%s' "$PR_BODY" | perl -0777 -pe 's/<!--.*?-->//gs')
+
+        CHERRY_PICK_LINE=$(printf '%s\n' "$PR_BODY" | grep -i "^cherry-pick:" | head -n 1 || true)
         if [[ -z "$CHERRY_PICK_LINE" ]]; then
           echo "No cherry-pick marker found in PR description"
           echo "versions=[]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes: CORE-1122

2 fixes for cherry-pick action.

was trying to add it to our nodejs agent repo, and run into those 2 issues:

- currently the action is hardcoded to accept major version as 1 and this is the only major it looks for. now make it configurable
- ignore PR body which is in comment, since there is a comment in the PR template that explains how to use the feature and it can trigger a cherry-pick itself.