### PR TITLE
CORE-1183: add instrumentation version updating actions - dispatch and apply

### DIFF
--- a/.github/chainguard/ro.sts.yaml
+++ b/.github/chainguard/ro.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: '^repo:odigos-io/ci-core:.*$'
+subject_pattern: '^repo:odigos-io/ci-core:pull_request$'
 
 permissions:
   contents: read

--- a/.github/chainguard/sts-test-role.sts.yaml
+++ b/.github/chainguard/sts-test-role.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: '^repo:odigos-io/ci-core:.*$'
+subject_pattern: '^repo:odigos-io/ci-core:pull_request$'
 
 permissions:
   contents: read

--- a/.github/chainguard/tag-releaser.sts.yaml
+++ b/.github/chainguard/tag-releaser.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: '^repo:odigos-io/ci-core:(tag:.*|ref:refs/heads/.*)$'
+subject_pattern: '^repo:odigos-io/ci-core:ref:(refs/tags/.*|refs/heads/.*)$'
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)
-1. [cherry-pick](./cherry-pick/README.md)
+2. [cherry-pick](./cherry-pick/README.md)
+3. [dispatch-agent-version-update](./dispatch-agent-version-update/README.md)
+4. [apply-agent-version-update](./apply-agent-version-update/README.md)
 
 ### Release and Deployment Notifications
 1. [slack-release-notification](./.github/actions/slack-release-notification/README.md)

--- a/apply-agent-version-update/README.md
+++ b/apply-agent-version-update/README.md
@@ -1,0 +1,87 @@
+# apply-agent-version-update
+
+Consumer-side half of the instrumentation-agent version-update flow. Runs the repo's
+`upgrade-agent` make target and, if anything changed, opens an auto-merging PR and notifies
+Slack.
+
+The per-repo mapping (category → image/module, Dockerfile vs go.mod) lives in that repo's
+`upgrade-agent` make target — not here.
+
+## Usage
+
+The calling job checks out the repo (with an `ro` STS token) and, when the bump touches
+`go.mod`, sets up Go + private-module read tokens, then invokes this action:
+
+```yaml
+jobs:
+  update-version-and-create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Resolve inputs
+        id: in
+        run: |  # map workflow_dispatch inputs / repository_dispatch payload -> instrumentation_agent + version
+          ...
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with: { scope: "${{ github.repository }}", identity: ro }
+      - uses: actions/checkout@v6
+        with: { token: "${{ steps.sts.outputs.GH_TOKEN }}" }
+      # (go-module repos only) setup-go + GOPRIVATE + private-deps read tokens here
+      - uses: odigos-io/ci-core/apply-agent-version-update@main
+        with:
+          instrumentation_agent: ${{ steps.in.outputs.instrumentation_agent }}
+          version: ${{ steps.in.outputs.version }}
+          make_dir: odiglet         # or "." for repo-root makefiles (vm-agent)
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `instrumentation_agent` | yes | — | Language instrumentation to update. |
+| `version` | yes | — | Version to set (e.g. `v0.11.0`). |
+| `make_dir` | no | `.` | Directory containing the repo's `agent-deps.mk`. |
+| `webhook-url` | yes | — | Slack webhook for the release-status notification. |
+| `automerge` | no | `true` | Enable auto-merge on the created PR. |
+
+## Contract
+
+Each consumer repo must expose an `agent-deps.mk` (in `make_dir`) with an `upgrade-agent` target:
+
+```
+make -f agent-deps.mk upgrade-agent INSTRUMENTATION_AGENT=<instrumentation_agent> AGENT_VERSION=<version>
+```
+
+It must update whatever that repo pins for the instrumentation (Dockerfile image tags and/or
+`go.mod`/`go.sum`) and **no-op on unknown instrumentations** so releases can broadcast safely.
+
+## Canonical instrumentations
+
+One value == one release stream. Standardized across all repos so a single dispatched
+`instrumentation_agent` routes correctly everywhere:
+
+`python`, `php`, `ruby`, `nodejs-community`, `nodejs-enterprise`, `python-ebpf`, `java-ebpf`,
+`golang` — and `cpp` once onboarded.
+
+## Onboarding a new agent (e.g. cpp) — zero framework change
+
+The slot is designed so a new agent needs no changes to this action or the wrappers:
+
+1. **Instrumentation repo** — in its release workflow, call
+   `odigos-io/ci-core/dispatch-agent-version-update@main` with `instrumentation_agent: cpp`,
+   `version: <tag>`, and `consumers` listing the repos that pin it (e.g.
+   `consumers: "odigos-enterprise vm-agent"`).
+2. **Each consuming repo** — add a `cpp)` branch to that repo's `upgrade-agent` make-target
+   dispatcher that updates whatever it pins (image tag via `upgrade-agent-image` /
+   `upgrade-odiglet-agent-version`, and/or a `go get <module>@$(AGENT_VERSION)` + `go mod tidy`,
+   or a `go mod edit -replace` for a forked module).
+3. **octo-sts** — ensure the instrumentation repo is trusted by each target consumer's
+   `trigger-agent-version-updater` identity, and (for go.mod bumps) that the consumer can read
+   the new module repo (`ro` octo-sts identity or `RELEASE_BOT_TOKEN`).
+
+No change to `ci-core/apply-agent-version-update`, `ci-core/dispatch-agent-version-update`, or any
+consumer wrapper workflow is required.

--- a/apply-agent-version-update/README.md
+++ b/apply-agent-version-update/README.md
@@ -9,8 +9,8 @@ The per-repo mapping (category → image/module, Dockerfile vs go.mod) lives in 
 
 ## Usage
 
-The calling job checks out the repo (with an `ro` STS token) and, when the bump touches
-`go.mod`, sets up Go + private-module read tokens, then invokes this action:
+The calling job checks out the repo with a read-only STS token, then invokes this action
+(repos whose bump touches `go.mod` set up Go and any private-module read tokens beforehand):
 
 ```yaml
 jobs:
@@ -20,22 +20,14 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Resolve inputs
-        id: in
-        run: |  # map workflow_dispatch inputs / repository_dispatch payload -> instrumentation_agent + version
-          ...
-      - uses: odigos-io/ci-core/sts@main
-        id: sts
-        with: { scope: "${{ github.repository }}", identity: ro }
-      - uses: actions/checkout@v6
-        with: { token: "${{ steps.sts.outputs.GH_TOKEN }}" }
-      # (go-module repos only) setup-go + GOPRIVATE + private-deps read tokens here
+      # resolve instrumentation_agent + version from the trigger payload
+      # checkout with a read-only STS token
       - uses: odigos-io/ci-core/apply-agent-version-update@main
         with:
           instrumentation_agent: ${{ steps.in.outputs.instrumentation_agent }}
           version: ${{ steps.in.outputs.version }}
-          make_dir: odiglet         # or "." for repo-root makefiles (vm-agent)
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          make_dir: <dir containing agent-deps.mk>
+          webhook-url: ${{ secrets.RELEASE_STATUS_WEBHOOK_URL }}
 ```
 
 ## Inputs
@@ -61,27 +53,18 @@ It must update whatever that repo pins for the instrumentation (Dockerfile image
 
 ## Canonical instrumentations
 
-One value == one release stream. Standardized across all repos so a single dispatched
-`instrumentation_agent` routes correctly everywhere:
+One `instrumentation_agent` value == one release stream, standardized across consuming repos so a
+single dispatched value routes correctly everywhere. The set of supported values is defined by each
+consumer repo's `upgrade-agent` make target; unknown values no-op.
 
-`python`, `php`, `ruby`, `nodejs-community`, `nodejs-enterprise`, `python-ebpf`, `java-ebpf`,
-`golang` — and `cpp` once onboarded.
+## Onboarding a new agent — zero framework change
 
-## Onboarding a new agent (e.g. cpp) — zero framework change
+A new agent needs no changes to this action or the dispatch action. In short:
 
-The slot is designed so a new agent needs no changes to this action or the wrappers:
+1. The instrumentation repo's release workflow calls `dispatch-agent-version-update` with the new
+   `instrumentation_agent` value and the `consumers` that pin it.
+2. Each consuming repo handles the new value in its own `upgrade-agent` make target.
+3. The relevant STS trust is granted in the consumer repos.
 
-1. **Instrumentation repo** — in its release workflow, call
-   `odigos-io/ci-core/dispatch-agent-version-update@main` with `instrumentation_agent: cpp`,
-   `version: <tag>`, and `consumers` listing the repos that pin it (e.g.
-   `consumers: "odigos-enterprise vm-agent"`).
-2. **Each consuming repo** — add a `cpp)` branch to that repo's `upgrade-agent` make-target
-   dispatcher that updates whatever it pins (image tag via `upgrade-agent-image` /
-   `upgrade-odiglet-agent-version`, and/or a `go get <module>@$(AGENT_VERSION)` + `go mod tidy`,
-   or a `go mod edit -replace` for a forked module).
-3. **octo-sts** — ensure the instrumentation repo is trusted by each target consumer's
-   `trigger-agent-version-updater` identity, and (for go.mod bumps) that the consumer can read
-   the new module repo (`ro` octo-sts identity or `RELEASE_BOT_TOKEN`).
-
-No change to `ci-core/apply-agent-version-update`, `ci-core/dispatch-agent-version-update`, or any
-consumer wrapper workflow is required.
+Repo-specific wiring (make targets, module read access, trust policies) lives in the consumer
+repos, not here.

--- a/apply-agent-version-update/action.yml
+++ b/apply-agent-version-update/action.yml
@@ -39,10 +39,13 @@ runs:
     - name: Detect changes
       id: diff
       shell: bash
+      env:
+        INSTRUMENTATION_AGENT: ${{ inputs.instrumentation_agent }}
+        AGENT_VERSION: ${{ inputs.version }}
       run: |
         if [ -z "$(git status --porcelain)" ]; then
           echo "changed=false" >> "$GITHUB_OUTPUT"
-          echo "No changes produced for ${{ inputs.instrumentation_agent }} -> ${{ inputs.version }} (instrumentation not consumed here, or already up to date)."
+          echo "No changes produced for $INSTRUMENTATION_AGENT -> $AGENT_VERSION (instrumentation not consumed here, or already up to date)."
         else
           echo "changed=true" >> "$GITHUB_OUTPUT"
         fi

--- a/apply-agent-version-update/action.yml
+++ b/apply-agent-version-update/action.yml
@@ -5,7 +5,7 @@ description: |
   auto-merging PR and notify Slack.
 inputs:
   instrumentation_agent:
-    description: "Language instrumentation to update (e.g. php, java-ebpf, golang)"
+    description: "Language instrumentation to update (e.g. php, java-ebpf, golang, cpp)"
     required: true
   version:
     description: "Version to set (e.g. v0.11.0)"

--- a/apply-agent-version-update/action.yml
+++ b/apply-agent-version-update/action.yml
@@ -1,0 +1,95 @@
+name: "Apply Agent Version Update"
+description: |
+  Shared consumer-side logic for an instrumentation-agent version bump: run the
+  repo's `upgrade-agent` make target, then (if anything changed) open an
+  auto-merging PR and notify Slack.
+inputs:
+  instrumentation_agent:
+    description: "Language instrumentation to update (e.g. php, java-ebpf, golang)"
+    required: true
+  version:
+    description: "Version to set (e.g. v0.11.0)"
+    required: true
+  make_dir:
+    description: "Directory containing the repo's agent-deps.mk to run `make` in (e.g. odiglet, or . for repo root)"
+    required: false
+    default: "."
+  webhook-url:
+    description: "Slack webhook URL for the release status notification"
+    required: true
+  automerge:
+    description: "Enable auto-merge on the created PR"
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Update agent version
+      shell: bash
+      working-directory: ${{ inputs.make_dir }}
+      env:
+        INSTRUMENTATION_AGENT: ${{ inputs.instrumentation_agent }}
+        AGENT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        make -f agent-deps.mk upgrade-agent \
+          INSTRUMENTATION_AGENT="$INSTRUMENTATION_AGENT" AGENT_VERSION="$AGENT_VERSION"
+
+    - name: Detect changes
+      id: diff
+      shell: bash
+      run: |
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No changes produced for ${{ inputs.instrumentation_agent }} -> ${{ inputs.version }} (instrumentation not consumed here, or already up to date)."
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Get agent version updater token
+      if: ${{ steps.diff.outputs.changed == 'true' }}
+      id: agent-version-sts
+      uses: odigos-io/ci-core/sts@main
+      with:
+        scope: ${{ github.repository }}
+        identity: agent-version-updater
+        output-git-config: "false"
+
+    - name: Create pull request
+      if: ${{ steps.diff.outputs.changed == 'true' }}
+      id: cpr
+      uses: peter-evans/create-pull-request@v8
+      with:
+        token: ${{ steps.agent-version-sts.outputs.GH_TOKEN }}
+        branch: update-${{ inputs.instrumentation_agent }}-agents-version-${{ inputs.version }}
+        title: "chore: update ${{ inputs.instrumentation_agent }} version to ${{ inputs.version }}"
+        body: |
+          Automated update of the **${{ inputs.instrumentation_agent }}** instrumentation agent to `${{ inputs.version }}`
+          (Dockerfile image tags and/or go.mod, as applicable for this repo).
+
+          **Triggered by:** ${{ github.event_name }}
+        commit-message: "chore: update ${{ inputs.instrumentation_agent }} version to ${{ inputs.version }}"
+        delete-branch: true
+        sign-commits: true
+        labels: |
+          new-agent-version
+          release-bot
+
+    - name: Enable Pull Request Automerge
+      if: ${{ steps.diff.outputs.changed == 'true' && inputs.automerge == 'true' && steps.cpr.outputs.pull-request-operation == 'created' }}
+      uses: peter-evans/enable-pull-request-automerge@v3
+      with:
+        token: ${{ steps.agent-version-sts.outputs.GH_TOKEN }}
+        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+        merge-method: squash
+
+    - name: Notify Slack
+      if: ${{ always() && (steps.cpr.outputs.pull-request-number != '' || job.status == 'failure') }}
+      uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+      with:
+        webhook-url: ${{ inputs.webhook-url }}
+        success-description: "Created PR to update ${{ inputs.instrumentation_agent }} version to ${{ inputs.version }}. Please review: ${{ steps.cpr.outputs.pull-request-url }}"
+        failure-description: "ERROR: Failed to update ${{ inputs.instrumentation_agent }} version to ${{ inputs.version }}"
+        tag: ${{ inputs.version }}
+        release-pr-link: ${{ steps.cpr.outputs.pull-request-url }}

--- a/dispatch-agent-version-update/README.md
+++ b/dispatch-agent-version-update/README.md
@@ -20,24 +20,22 @@ jobs:
         with:
           instrumentation_agent: php
           version: ${{ needs.calculate.outputs.new_version }}
-          # consumers omitted -> dispatches to all three. For an enterprise-only agent:
-          # consumers: "odigos-enterprise&vm-agent"
+          # consumers omitted -> dispatches to all defaults.
+          # Set consumers to target a subset, e.g. consumers: "vm-agent"
 ```
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `instrumentation_agent` | yes | — | Language instrumentation being released (`php`, `ruby`, `python`, `java-ebpf`, `python-ebpf`, `nodejs-community`, `nodejs-enterprise`, `golang`, …). |
+| `instrumentation_agent` | yes | — | Language instrumentation being released (e.g. `php`, `ruby`, `python`, `golang`, …). |
 | `version` | yes | — | Released version to propagate (e.g. `v0.11.0`). |
 | `consumers` | no | `odigos&odigos-enterprise&vm-agent` | `&`-separated consumer repos to dispatch to (commas/spaces/newlines also accepted). Valid: `odigos`, `odigos-enterprise`, `vm-agent`. |
 
 ## Notes
 
-- The instrumentation repo must be trusted by each targeted consumer's
-  `trigger-agent-version-updater` octo-sts identity.
+- The instrumentation repo must be trusted by each targeted consumer's STS dispatch identity.
 - Broadcasting to a consumer that doesn't pin this instrumentation is safe: its `upgrade-agent`
-  make target no-ops on unknown instrumentations. (Still, set `consumers` to the repos that
-  actually consume it so an STS-untrusted consumer isn't dispatched to.)
-- This action does not post to Slack — the instrumentation's own release workflow already
-  notifies on publish, and the consumer-side `apply-agent-version-update` posts the PR link.
+  make target no-ops on unknown values. Still, set `consumers` to the repos that actually consume
+  it so an untrusted consumer isn't dispatched to.
+- This action does not post to Slack — the consumer-side `apply-agent-version-update` posts the PR link.

--- a/dispatch-agent-version-update/README.md
+++ b/dispatch-agent-version-update/README.md
@@ -1,0 +1,43 @@
+# dispatch-agent-version-update
+
+Dispatch an instrumentation-agent version bump from a release workflow to the odigos
+consumer repos (`odigos`, `odigos-enterprise`, `vm-agent`).
+
+The consumer, afterwards, applies it via [`apply-agent-version-update`](../apply-agent-version-update).
+
+## Usage
+
+```yaml
+jobs:
+  trigger-odigos-update:
+    needs: [calculate, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for the STS OIDC exchange
+      contents: read
+    steps:
+      - uses: odigos-io/ci-core/dispatch-agent-version-update@main
+        with:
+          instrumentation_agent: php
+          version: ${{ needs.calculate.outputs.new_version }}
+          # consumers omitted -> dispatches to all three. For an enterprise-only agent:
+          # consumers: "odigos-enterprise&vm-agent"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `instrumentation_agent` | yes | — | Language instrumentation being released (`php`, `ruby`, `python`, `java-ebpf`, `python-ebpf`, `nodejs-community`, `nodejs-enterprise`, `golang`, …). |
+| `version` | yes | — | Released version to propagate (e.g. `v0.11.0`). |
+| `consumers` | no | `odigos&odigos-enterprise&vm-agent` | `&`-separated consumer repos to dispatch to (commas/spaces/newlines also accepted). Valid: `odigos`, `odigos-enterprise`, `vm-agent`. |
+
+## Notes
+
+- The instrumentation repo must be trusted by each targeted consumer's
+  `trigger-agent-version-updater` octo-sts identity.
+- Broadcasting to a consumer that doesn't pin this instrumentation is safe: its `upgrade-agent`
+  make target no-ops on unknown instrumentations. (Still, set `consumers` to the repos that
+  actually consume it so an STS-untrusted consumer isn't dispatched to.)
+- This action does not post to Slack — the instrumentation's own release workflow already
+  notifies on publish, and the consumer-side `apply-agent-version-update` posts the PR link.

--- a/dispatch-agent-version-update/action.yml
+++ b/dispatch-agent-version-update/action.yml
@@ -1,0 +1,93 @@
+name: "Dispatch Agent Version Update"
+description: |
+  Dispatch an instrumentation-agent version bump from a release workflow to the odigos
+  consumer repos.
+  This action is called by an instrumentation repo's release workflow to dispatch the version bump to the consumer repos.
+
+  After the version bump is dispatched, the consumer repo will apply the version bump via the apply-agent-version-update action.
+inputs:
+  instrumentation_agent:
+    description: "Language instrumentation being released (e.g. php, ruby, python, golang)"
+    required: true
+  version:
+    description: "Released version to propagate (e.g. v0.11.0)"
+    required: true
+  consumers:
+    description: |
+      '&'-separated list of consumer repos to dispatch to (commas/spaces/newlines also accepted).
+      Valid entries: odigos, odigos-enterprise, vm-agent.
+      Defaults to all three (consumers that don't pin this instrumentation no-op safely).
+    required: false
+    default: "odigos&odigos-enterprise&vm-agent"
+
+runs:
+  using: composite
+  steps:
+    - name: Parse consumers
+      id: targets
+      shell: bash
+      env:
+        CONSUMERS: ${{ inputs.consumers }}
+      run: |
+        # Normalize separators (commas/newlines/spaces) to a single '&' delimiter and
+        # wrap with '&' on both ends, so `&odigos&` matches exactly and never collides
+        # with `&odigos-enterprise&`.
+        norm="&$(printf '%s' "$CONSUMERS" | tr ',\n ' '&&&' | tr -s '&')&"
+        echo "list=$norm" >> "$GITHUB_OUTPUT"
+
+    # ── odigos (OSS) ────────────────────────────────────────────────────────────
+    - name: Get sts token for Odigos OSS repo
+      if: ${{ contains(steps.targets.outputs.list, '&odigos&') }}
+      id: sts-oss
+      uses: odigos-io/ci-core/sts@main
+      with:
+        scope: odigos-io/odigos
+        identity: trigger-agent-version-updater
+        output-git-config: "false"
+
+    - name: Trigger update in Odigos OSS
+      if: ${{ contains(steps.targets.outputs.list, '&odigos&') }}
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ steps.sts-oss.outputs.GH_TOKEN }}
+        repository: odigos-io/odigos
+        event-type: update-instrumentation-agents-version
+        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'
+
+    # ── odigos-enterprise ─────────────────────────────────────────────────────────
+    - name: Get sts token for Odigos Enterprise repo
+      if: ${{ contains(steps.targets.outputs.list, '&odigos-enterprise&') }}
+      id: sts-enterprise
+      uses: odigos-io/ci-core/sts@main
+      with:
+        scope: odigos-io/odigos-enterprise
+        identity: trigger-agent-version-updater
+        output-git-config: "false"
+
+    - name: Trigger update in Odigos Enterprise
+      if: ${{ contains(steps.targets.outputs.list, '&odigos-enterprise&') }}
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ steps.sts-enterprise.outputs.GH_TOKEN }}
+        repository: odigos-io/odigos-enterprise
+        event-type: update-instrumentation-agents-version
+        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'
+
+    # ── vm-agent ──────────────────────────────────────────────────────────────────
+    - name: Get sts token for VM Agent repo
+      if: ${{ contains(steps.targets.outputs.list, '&vm-agent&') }}
+      id: sts-vmagent
+      uses: odigos-io/ci-core/sts@main
+      with:
+        scope: odigos-io/vm-agent
+        identity: trigger-agent-version-updater
+        output-git-config: "false"
+
+    - name: Trigger update in VM Agent
+      if: ${{ contains(steps.targets.outputs.list, '&vm-agent&') }}
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ steps.sts-vmagent.outputs.GH_TOKEN }}
+        repository: odigos-io/vm-agent
+        event-type: update-instrumentation-agents-version
+        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'

--- a/dispatch-agent-version-update/action.yml
+++ b/dispatch-agent-version-update/action.yml
@@ -35,6 +35,18 @@ runs:
         norm="&$(printf '%s' "$CONSUMERS" | tr ',\n ' '&&&' | tr -s '&')&"
         echo "list=$norm" >> "$GITHUB_OUTPUT"
 
+    - name: Build dispatch payload
+      id: payload
+      shell: bash
+      env:
+        INSTRUMENTATION_AGENT: ${{ inputs.instrumentation_agent }}
+        AGENT_VERSION: ${{ inputs.version }}
+      run: |
+        # Build JSON with jq so input values are safely escaped (no JSON/expression injection).
+        json="$(jq -nc --arg agent "$INSTRUMENTATION_AGENT" --arg version "$AGENT_VERSION" \
+          '{instrumentation_agent: $agent, new_agent_version: $version}')"
+        echo "json=$json" >> "$GITHUB_OUTPUT"
+
     # ── odigos (OSS) ────────────────────────────────────────────────────────────
     - name: Get sts token for Odigos OSS repo
       if: ${{ contains(steps.targets.outputs.list, '&odigos&') }}
@@ -52,7 +64,7 @@ runs:
         token: ${{ steps.sts-oss.outputs.GH_TOKEN }}
         repository: odigos-io/odigos
         event-type: update-instrumentation-agents-version
-        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'
+        client-payload: ${{ steps.payload.outputs.json }}
 
     # ── odigos-enterprise ─────────────────────────────────────────────────────────
     - name: Get sts token for Odigos Enterprise repo
@@ -71,7 +83,7 @@ runs:
         token: ${{ steps.sts-enterprise.outputs.GH_TOKEN }}
         repository: odigos-io/odigos-enterprise
         event-type: update-instrumentation-agents-version
-        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'
+        client-payload: ${{ steps.payload.outputs.json }}
 
     # ── vm-agent ──────────────────────────────────────────────────────────────────
     - name: Get sts token for VM Agent repo
@@ -90,4 +102,4 @@ runs:
         token: ${{ steps.sts-vmagent.outputs.GH_TOKEN }}
         repository: odigos-io/vm-agent
         event-type: update-instrumentation-agents-version
-        client-payload: '{"instrumentation_agent": "${{ inputs.instrumentation_agent }}", "new_agent_version": "${{ inputs.version }}"}'
+        client-payload: ${{ steps.payload.outputs.json }}


### PR DESCRIPTION
These replace the flows in the instrumentation agent repos and the oss/enterprise/vm agent repos