### PR TITLE
CORE-1077: fix(generate-release-notes): peel annotated tags to commit SHAs

### DIFF
--- a/generate-release-notes/README.md
+++ b/generate-release-notes/README.md
@@ -98,7 +98,7 @@ jobs:
 
 - **Workflow artifact:** The action always uploads a `release-notes` artifact containing the full `release-notes.md`, so other jobs can download it.
 - **Release body:** Unless `dry-run` is `true`, the action updates the GitHub release for `tag` with the generated notes.
-- **Truncation:** If the notes exceed GitHub’s limit (~124k chars), the release body is truncated and a note is appended. The **full** `release-notes.md` is still in the artifact and is also attached to the release as a `release-notes.md` asset when truncated.
+- **Truncation:** If the notes exceed GitHub’s limit (~124k chars), the release body is truncated and a note is appended. The **full** `release-notes.md` is still in the artifact and is also attached to the release as a `release-notes.md` asset when truncated (skipped if the file is empty — GitHub rejects zero-byte assets).
 
 ### How the commit range is chosen
 

--- a/generate-release-notes/README.md
+++ b/generate-release-notes/README.md
@@ -112,6 +112,8 @@ The action picks `START_SHA` (and uses `END_SHA` = the tag commit) based on the 
 
 Only exact semver tags (`vX.Y.Z` or `vX.Y.Z-rcN`) are considered; namespaced tags like `profiles/v1.17.0` are ignored.
 
+Previous tags are resolved to their **commit** SHA (`tag^{commit}`), so annotated or GPG-signed tags work the same as lightweight tags when computing `START_SHA`.
+
 ## Local testing with act
 
 You can run the workflow locally with [act](https://github.com/nektos/act). From the repo that uses the action (e.g. `odigos-io/odigos`):

--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -74,6 +74,11 @@ runs:
           END_SHA=$(git rev-parse HEAD)
           echo "end_sha=${END_SHA}" >> $GITHUB_OUTPUT
 
+          # Peel annotated/signed tags to the commit they point at. Plain rev-parse
+          # returns the tag object SHA for annotated tags, which the release-notes
+          # tool cannot resolve via the GitHub commits API.
+          tag_commit_sha() { git rev-parse "${1}^{commit}"; }
+
           # Only consider exact semver release tags (vX.Y.Z or vX.Y.Z-rcN), not namespaced ones like profiles/v1.17.0
           is_release_tag() { [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; }
           list_merged_release_tags() {
@@ -102,7 +107,7 @@ runs:
             done < <(list_merged_release_tags)
 
             if [ -n "$PREV_RC_TAG" ]; then
-              START_SHA=$(git rev-parse "$PREV_RC_TAG")
+              START_SHA=$(tag_commit_sha "$PREV_RC_TAG")
               echo "start_sha=${START_SHA}" >> $GITHUB_OUTPUT
               echo "Scenario: RC after previous RC, PREV_RC_TAG=$PREV_RC_TAG"
             else
@@ -143,7 +148,7 @@ runs:
             done
 
             if [ -n "$PREV_STABLE_TAG" ]; then
-              START_SHA=$(git rev-parse "$PREV_STABLE_TAG")
+              START_SHA=$(tag_commit_sha "$PREV_STABLE_TAG")
               echo "start_sha=${START_SHA}" >> $GITHUB_OUTPUT
               echo "Scenario: patch release, PREV_STABLE_TAG=$PREV_STABLE_TAG"
             else

--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -250,6 +250,7 @@ runs:
           GH_TOKEN: ${{ steps.sts.outputs.GH_TOKEN || inputs.github-token }}
         run: |
           gh release edit "${{ inputs.tag }}" --repo "${{ github.repository }}" --notes-file release-notes-gh.md
-          if [ "${{ steps.truncate.outputs.truncated }}" == "true" ]; then
+          # GitHub rejects zero-byte release assets with HTTP 400 Bad Content-Length.
+          if [ "${{ steps.truncate.outputs.truncated }}" == "true" ] && [ -s release-notes.md ]; then
             gh release upload "${{ inputs.tag }}" release-notes.md --repo "${{ github.repository }}" --clobber
           fi


### PR DESCRIPTION
## Summary

- Fix intermittent release-notes generation failures when the previous release tag is an annotated (e.g. GPG-signed) tag instead of a lightweight tag.
- Resolve previous RC/stable tags with `git rev-parse "${tag}^{commit}"` so `START_SHA` is always a commit SHA the Kubernetes `release-notes` tool can fetch via the GitHub commits API.

## Problem

The `generate-release-notes` action computes `START_SHA` with plain `git rev-parse "$PREV_*_TAG"`. For annotated tags, that returns the **tag object** SHA, not the commit it points to. The release-notes tool then calls:

See for example this run in vm-agent: https://github.com/odigos-io/vm-agent/actions/runs/28157665159/job/83390102244

It [failed with](https://github.com/odigos-io/vm-agent/actions/runs/28157665159/job/83390102244#step:9:780):

```
level=fatal msg="gathering release notes: listing release notes: listing commits: retrieve start commit: GET https://api.github.com/repos/odigos-io/vm-agent/git/commits/5d07f032c81312fc2b0ffa5706efcba0a60e9961: 404 Not Found []"
```

This also addresses an option to skip the truncated notes upload if the file is empty (leading to a bad content length error like this run: https://github.com/odigos-io/vm-agent/actions/runs/26213746592/job/77130758532#step:11:30)