### PR TITLE
DEVOPS-58: Add resolve-build-labels action for PR-driven Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 1. [require-linear](./require-linear/README.md)
 1. [require-release-note](./require-release-note/README.md)
 
+### Build Configuration
+1. [resolve-build-labels](./resolve-build-labels/README.md)
+
 ### Security and Vulnerability Scanning
 1. [vulnerabilities-scanner](./vulnerabilities-scanner/README.md)
 

--- a/resolve-build-labels/README.md
+++ b/resolve-build-labels/README.md
@@ -1,0 +1,76 @@
+# Resolve Build Labels
+
+Reads pull request labels and exposes Docker build options for consuming workflows.
+
+## Labels
+
+| Label | Effect | Default (label absent) |
+|-------|--------|------------------------|
+| `build: arm` | Build for `linux/amd64` and `linux/arm64` | `linux/amd64` only |
+| `build: no-cache` | Build without Docker layer cache | Cache enabled |
+
+Create these labels in each consuming repository (or via org-level label sync). Label names are exact matches, including the space after the colon.
+
+## Outputs
+
+| Output | Description | Example |
+|--------|-------------|---------|
+| `build-arm` | `true` if `build: arm` is present | `true` / `false` |
+| `no-cache` | `true` if `build: no-cache` is present | `true` / `false` |
+| `platforms` | Platforms string for `docker/build-push-action` | `linux/amd64` or `linux/amd64,linux/arm64` |
+
+Outside of `pull_request` events (no labels in context), outputs fall back to amd64-only with cache enabled.
+
+## Permission Requirements
+
+* `pull-requests: read` — to read PR labels from the event payload.
+
+## Usage
+
+Include `labeled` and `unlabeled` in the workflow's `pull_request` types so adding or removing a label re-runs CI:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve build options from PR labels
+        id: build-opts
+        uses: odigos-io/ci-core/resolve-build-labels@main
+
+      - name: Set up QEMU
+        if: steps.build-opts.outputs.build-arm == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ steps.build-opts.outputs.platforms }}
+          no-cache: ${{ steps.build-opts.outputs.no-cache }}
+          # When using registry/GHA cache, also gate cache-* on the label:
+          # cache-from: ${{ steps.build-opts.outputs.no-cache != 'true' && 'type=gha' || '' }}
+          # cache-to: ${{ steps.build-opts.outputs.no-cache != 'true' && 'type=gha,mode=max' || '' }}
+          push: false
+          tags: myimage:pr
+```
+
+## Examples
+
+- No labels → `platforms=linux/amd64`, `no-cache=false`
+- `build: arm` → `platforms=linux/amd64,linux/arm64`, `no-cache=false`
+- `build: no-cache` → `platforms=linux/amd64`, `no-cache=true`
+- Both labels → `platforms=linux/amd64,linux/arm64`, `no-cache=true`

--- a/resolve-build-labels/action.yml
+++ b/resolve-build-labels/action.yml
@@ -1,0 +1,63 @@
+name: "Resolve Build Labels"
+description: |
+  Reads pull request labels to decide Docker build options.
+  Supported labels: "build: arm" (also build linux/arm64) and "build: no-cache"
+  (build without Docker layer cache). Defaults to linux/amd64 with cache enabled.
+
+outputs:
+  build-arm:
+    description: "true if the PR has the 'build: arm' label"
+    value: ${{ steps.resolve.outputs.build-arm }}
+  no-cache:
+    description: "true if the PR has the 'build: no-cache' label"
+    value: ${{ steps.resolve.outputs.no-cache }}
+  platforms:
+    description: "Docker platforms string (linux/amd64 or linux/amd64,linux/arm64)"
+    value: ${{ steps.resolve.outputs.platforms }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve build options from PR labels
+      id: resolve
+      shell: bash
+      env:
+        # Comma-joined label names; empty outside pull_request events.
+        PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+      run: |
+        set -euo pipefail
+
+        BUILD_ARM=false
+        NO_CACHE=false
+
+        IFS=',' read -ra LABELS <<< "${PR_LABELS}"
+        for label in "${LABELS[@]}"; do
+          case "$label" in
+            "build: arm")
+              BUILD_ARM=true
+              ;;
+            "build: no-cache")
+              NO_CACHE=true
+              ;;
+          esac
+        done
+
+        if [ "$BUILD_ARM" = true ]; then
+          PLATFORMS="linux/amd64,linux/arm64"
+        else
+          PLATFORMS="linux/amd64"
+        fi
+
+        echo "build-arm=${BUILD_ARM}" >> "$GITHUB_OUTPUT"
+        echo "no-cache=${NO_CACHE}" >> "$GITHUB_OUTPUT"
+        echo "platforms=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+
+        echo "## Build options from PR labels" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Option | Value | Label |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|--------|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Platforms | \`${PLATFORMS}\` | \`build: arm\` → ${BUILD_ARM} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| No cache | \`${NO_CACHE}\` | \`build: no-cache\` → ${NO_CACHE} |" >> "$GITHUB_STEP_SUMMARY"
+
+        echo "Platforms: ${PLATFORMS}"
+        echo "No cache: ${NO_CACHE}"


### PR DESCRIPTION
## Summary
- Add `resolve-build-labels` composite action that reads PR labels (`build: arm`, `build: no-cache`) and outputs Docker build options (`platforms`, `no-cache`, `build-arm`)
- Document usage for consuming workflows (include `labeled`/`unlabeled` types; wire into `docker/build-push-action`)
- Link the action from the root README

Linear: https://linear.app/odigos/issue/DEVOPS-58/add-resolve-build-labels-ci-action-for-pr-driven-docker-build-options

## Test plan
- [ ] Create labels `build: arm` and `build: no-cache` in a consumer repo
- [ ] Open a PR with no labels → expect `platforms=linux/amd64`, `no-cache=false`
- [ ] Add `build: arm` → expect `platforms=linux/amd64,linux/arm64`
- [ ] Add `build: no-cache` → expect `no-cache=true`
- [ ] Confirm workflow re-runs on `labeled`/`unlabeled` when those event types are configured


Made with [Cursor](https://cursor.com)