### PR TITLE
RUN-1024: add sign-oci action for keyless container image signing

### DIFF
--- a/.github/workflows/test-sign-oci.yml
+++ b/.github/workflows/test-sign-oci.yml
@@ -1,0 +1,284 @@
+name: sign-oci Test
+
+# Exercises sign-oci end to end against a throwaway multi-arch image in GHCR,
+# so the action can be changed without burning a real release.
+#
+# GHCR is used rather than Artifact Registry deliberately: auth is just
+# GITHUB_TOKEN, so this needs no cloud secrets and no IAM prerequisite.
+#
+# The negative assertions are the point. A verify that passes proves very
+# little on its own — what matters is that verification FAILS for the wrong
+# identity, the wrong issuer, and an unsigned digest.
+
+on:
+  pull_request:
+    paths:
+      - 'sign-oci/**'
+      - '.github/workflows/test-sign-oci.yml'
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  TEST_IMAGE: ghcr.io/${{ github.repository_owner }}/ci-core-signing-test
+
+jobs:
+  # Bad input must be rejected before anything is signed. These never reach a
+  # registry — the action's validate step aborts first.
+  input-validation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject a digest that is not sha256:<64 hex>
+        id: bad-digest
+        continue-on-error: true
+        uses: ./sign-oci
+        with:
+          refs: ghcr.io/odigos-io/nope
+          digest: v1.2.3
+
+      - name: Reject a ref carrying a tag
+        id: tagged-ref
+        continue-on-error: true
+        uses: ./sign-oci
+        with:
+          refs: ghcr.io/odigos-io/nope:v1
+          digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+      - name: Reject empty refs
+        id: empty-refs
+        continue-on-error: true
+        uses: ./sign-oci
+        with:
+          refs: "   "
+          digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+      - name: Reject an unknown sbom-type
+        id: bad-sbom-type
+        continue-on-error: true
+        uses: ./sign-oci
+        with:
+          refs: ghcr.io/odigos-io/nope
+          digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+          sbom-type: spdx
+
+      - name: Assert every invalid input was rejected
+        env:
+          BAD_DIGEST: ${{ steps.bad-digest.outcome }}
+          TAGGED_REF: ${{ steps.tagged-ref.outcome }}
+          EMPTY_REFS: ${{ steps.empty-refs.outcome }}
+          BAD_SBOM_TYPE: ${{ steps.bad-sbom-type.outcome }}
+        run: |
+          set -euo pipefail
+          rc=0
+          for case in BAD_DIGEST TAGGED_REF EMPTY_REFS BAD_SBOM_TYPE; do
+            if [[ "${!case}" == "failure" ]]; then
+              echo "ok (correctly rejected): $case"
+            else
+              echo "::error::$case was accepted but should have been rejected (outcome=${!case})"
+              rc=1
+            fi
+          done
+          exit $rc
+
+  sign-and-verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # push the test image and its signature to GHCR
+      id-token: write   # mint the Fulcio cert for keyless signing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build a throwaway multi-arch image
+        id: build
+        run: |
+          set -euo pipefail
+          ctx="$(mktemp -d)"
+          # Content varies per run so each run gets its own digest.
+          printf 'ci-core sign-oci test %s\n' "${GITHUB_RUN_ID}" > "${ctx}/hello.txt"
+          # A real base image, not FROM scratch: syft needs actual packages to
+          # discover, otherwise the SBOM is an empty document and the
+          # attestation assertion below proves nothing.
+          cat > "${ctx}/Dockerfile" <<'EOF'
+          FROM alpine:3.22
+          COPY hello.txt /hello.txt
+          EOF
+
+          # provenance:false keeps the index to exactly two platform children,
+          # matching how the org publishes today.
+          docker buildx build "$ctx" \
+            --platform linux/amd64,linux/arm64 \
+            --provenance=false \
+            --tag "${TEST_IMAGE}:run-${GITHUB_RUN_ID}" \
+            --metadata-file meta.json \
+            --push
+
+          digest="$(jq -r '.["containerimage.digest"]' meta.json)"
+          [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || { echo "::error::no digest from buildx"; exit 1; }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Built ${TEST_IMAGE}@${digest}"
+
+      # ---- dry run: must produce no signature -------------------------------
+
+      - name: Sign with dry-run
+        uses: ./sign-oci
+        with:
+          refs: ${{ env.TEST_IMAGE }}
+          digest: ${{ steps.build.outputs.digest }}
+          dry-run: "true"
+
+      - name: Assert dry-run left the image unsigned
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign version
+          if cosign verify \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity-regexp '.*' \
+              "${TEST_IMAGE}@${DIGEST}" >/dev/null 2>&1; then
+            echo "::error::dry-run uploaded a signature — it must not"
+            exit 1
+          fi
+          echo "ok: no signature present after dry-run"
+
+      # ---- real run ----------------------------------------------------------
+
+      - name: Sign for real
+        uses: ./sign-oci
+        with:
+          refs: ${{ env.TEST_IMAGE }}
+          digest: ${{ steps.build.outputs.digest }}
+
+      - name: Verify signature and SBOM attestation
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          ISSUER=https://token.actions.githubusercontent.com
+          # workflow_dispatch -> refs/heads/<branch>; pull_request -> refs/pull/<n>/merge
+          IDENTITY='^https://github\.com/odigos-io/ci-core/\.github/workflows/test-sign-oci\.yml@refs/(heads|pull)/.*$'
+
+          echo "::group::verify image signature"
+          cosign verify \
+            --certificate-oidc-issuer "$ISSUER" \
+            --certificate-identity-regexp "$IDENTITY" \
+            "${TEST_IMAGE}@${DIGEST}"
+          echo "::endgroup::"
+
+          echo "::group::verify SBOM attestation"
+          cosign verify-attestation --type cyclonedx \
+            --certificate-oidc-issuer "$ISSUER" \
+            --certificate-identity-regexp "$IDENTITY" \
+            "${TEST_IMAGE}@${DIGEST}" > attestation.json
+          # The attestation must carry a real SBOM, not an empty envelope.
+          jq -r '.payload' attestation.json | base64 -d > statement.json
+          predicate_type=$(jq -r '.predicateType' statement.json)
+          components=$(jq '.predicate.components | length // 0' statement.json)
+          echo "predicateType: ${predicate_type}"
+          if [[ "${components:-0}" -le 0 ]]; then
+            echo "::error::SBOM attestation has no components (predicateType=${predicate_type})"
+            jq -c '.predicate | keys' statement.json || true
+            exit 1
+          fi
+          echo "ok: SBOM attestation carries ${components} components"
+          echo "::endgroup::"
+
+      - name: Verify each per-arch child manifest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          ISSUER=https://token.actions.githubusercontent.com
+          IDENTITY='^https://github\.com/odigos-io/ci-core/\.github/workflows/test-sign-oci\.yml@refs/(heads|pull)/.*$'
+
+          # This is the only assertion that proves --recursive did anything.
+          # Consumers that resolve a child directly (COPY --from, crane pull
+          # --platform) depend on these signatures existing.
+          mapfile -t children < <(
+            docker buildx imagetools inspect --raw "${TEST_IMAGE}@${DIGEST}" \
+              | jq -r '.manifests[] | select(.platform.architecture=="amd64" or .platform.architecture=="arm64") | .digest'
+          )
+
+          [[ "${#children[@]}" -eq 2 ]] || { echo "::error::expected 2 platform children, got ${#children[@]}"; exit 1; }
+
+          for child in "${children[@]}"; do
+            echo "verifying child $child"
+            cosign verify \
+              --certificate-oidc-issuer "$ISSUER" \
+              --certificate-identity-regexp "$IDENTITY" \
+              "${TEST_IMAGE}@${child}"
+          done
+          echo "ok: both platform children verify"
+
+      - name: Assert verification fails for the wrong identity
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          ISSUER=https://token.actions.githubusercontent.com
+          GOOD='^https://github\.com/odigos-io/ci-core/\.github/workflows/test-sign-oci\.yml@refs/(heads|pull)/.*$'
+
+          must_fail() {
+            local desc="$1"; shift
+            if "$@" >/dev/null 2>&1; then
+              echo "::error::${desc} — verification SUCCEEDED but must fail"
+              exit 1
+            fi
+            echo "ok (correctly rejected): ${desc}"
+          }
+
+          # A policy that accepts a signature from another repo's workflow is
+          # not a policy. These are the assertions that give the positive test
+          # its meaning.
+          must_fail "identity from a different repo" \
+            cosign verify --certificate-oidc-issuer "$ISSUER" \
+              --certificate-identity-regexp '^https://github\.com/odigos-io/some-other-repo/.*$' \
+              "${TEST_IMAGE}@${DIGEST}"
+
+          must_fail "identity from a different workflow in this repo" \
+            cosign verify --certificate-oidc-issuer "$ISSUER" \
+              --certificate-identity-regexp '^https://github\.com/odigos-io/ci-core/\.github/workflows/publish\.yml@.*$' \
+              "${TEST_IMAGE}@${DIGEST}"
+
+          must_fail "wrong OIDC issuer" \
+            cosign verify --certificate-oidc-issuer https://accounts.google.com \
+              --certificate-identity-regexp "$GOOD" \
+              "${TEST_IMAGE}@${DIGEST}"
+
+          must_fail "attestation type that was never attested" \
+            cosign verify-attestation --type slsaprovenance \
+              --certificate-oidc-issuer "$ISSUER" --certificate-identity-regexp "$GOOD" \
+              "${TEST_IMAGE}@${DIGEST}"
+
+      # Old untagged versions of ci-core-signing-test accumulate in GHCR. Prune
+      # the package periodically; automating it here would mean granting this
+      # workflow packages: delete, which is not worth it for a test image.
+      - name: Summary
+        if: always()
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### sign-oci test"
+            echo
+            echo "- image: \`${TEST_IMAGE}@${DIGEST}\`"
+            echo "- tag:   \`run-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@
 ### Build Configuration
 1. [resolve-build-labels](./resolve-build-labels/README.md)
 
-### Security and Vulnerability Scanning
+### Security and Supply Chain
 1. [vulnerabilities-scanner](./vulnerabilities-scanner/README.md)
+2. [sign-oci](./sign-oci/README.md) — keyless cosign signing and SBOM attestation for published images
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)

--- a/sign-oci/README.md
+++ b/sign-oci/README.md
@@ -1,0 +1,91 @@
+# sign-oci
+
+Keyless-signs a pushed container image with [cosign](https://github.com/sigstore/cosign) and attaches a [syft](https://github.com/anchore/syft) SBOM attestation. The job's OIDC token is exchanged for a short-lived Fulcio certificate and the signature is recorded in the public Rekor log — there is no key to store or rotate.
+
+## Usage
+
+```yaml
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write        # required — cosign mints its cert from this
+    steps:
+      # ... registry login ...
+
+      - name: Build and push
+        id: build            # required — sign-oci needs the digest
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: us-central1-docker.pkg.dev/odigos-cloud/components/my-image:v1.2.3
+
+      - name: Sign
+        uses: odigos-io/ci-core/sign-oci@main
+        with:
+          refs: us-central1-docker.pkg.dev/odigos-cloud/components/my-image
+          digest: ${{ steps.build.outputs.digest }}
+```
+
+Pass **every** registry the digest was pushed to — a signature is stored beside the image in one registry and does not travel with a copy:
+
+```yaml
+    refs: |
+      us-central1-docker.pkg.dev/odigos-cloud/components/odigos-odiglet
+      ghcr.io/odigos-io/odigos-odiglet
+      keyval/odigos-odiglet
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `refs` | yes | | Newline-separated registry paths **without** a tag or digest |
+| `digest` | yes | | `sha256:...`, from `steps.<build>.outputs.digest` |
+| `recursive` | no | `true` | Sign child manifests as well as the index |
+| `sbom` | no | `true` | Generate and attach an SBOM attestation |
+| `sbom-type` | no | `cyclonedx` | `cyclonedx` or `spdxjson` |
+| `cosign-version` | no | `3.1.2` | Pinned cosign version |
+| `syft-version` | no | `1.50.0` | Pinned syft version |
+| `dry-run` | no | `false` | Sign without uploading |
+
+No outputs. The SBOM is left at `sbom.json` in the workspace.
+
+## Things that will bite you
+
+**Run it in the same job as the push.** It uses the docker keychain the caller already established; a separate job gets a fresh runner with no credentials. The calling job also needs `id-token: write` — composite actions cannot declare their own permissions — plus `packages: write` for `ghcr.io` refs.
+
+**It refuses tags, by design.** Tags here are mutable (`:latest` moves on most publishes, RC digests get retagged to stable), so signing one is a TOCTOU hole. Both `refs` and `digest` are validated.
+
+**Signatures do not survive `crane copy`.** Copying moves the manifest and nothing else. Sign at the destination too. Note `cosign copy` is deprecated in cosign 3.x in favour of `oras copy -r`.
+
+**The SBOM covers the index, and one platform.** `cosign attest` has no `--recursive`, so the attestation attaches to the index digest only — a consumer resolving a child directly (`COPY --from`, `crane pull --platform`) can verify the signature but not the SBOM. And syft resolves a single child of a multi-arch index, so the SBOM describes whichever arch it picked.
+
+**Storage layout varies by registry.** cosign 3.x prefers the OCI referrers API and falls back to the referrers *tag* schema — a tag named `sha256-<digest>`, no `.sig`/`.att` suffix — where the registry lacks it (GHCR does). Don't assume a shape in tooling that enumerates signatures.
+
+**Nothing shows in the GitHub UI.** The Attestations tab and `gh attestation verify` only cover GitHub's own store, which cosign never writes to. Use `cosign tree <ref>@<digest>`.
+
+## Verifying
+
+```bash
+ISS=https://token.actions.githubusercontent.com
+ID='^https://github\.com/odigos-io/<repo>/\.github/workflows/<workflow>\.yml@refs/(heads|tags)/.*$'
+
+cosign tree "<ref>@<digest>"
+cosign verify --certificate-oidc-issuer "$ISS" --certificate-identity-regexp "$ID" "<ref>@<digest>"
+
+cosign verify-attestation --type cyclonedx \
+  --certificate-oidc-issuer "$ISS" --certificate-identity-regexp "$ID" "<ref>@<digest>" \
+  | jq -r .payload | base64 -d | jq -r '.predicate.components[] | "\(.name) \(.version)"'
+```
+
+Never use a blanket `.*odigos-io.*` identity pattern — that lets any workflow in any org repo, including PR CI, mint a signature that passes.
+
+Airgapped verification changed in cosign 3.x: `--offline` is deprecated in favour of `--bundle` plus a `--trusted-root` file.
+
+## Dependencies
+
+Two, both SHA-pinned: `sigstore/cosign-installer` (verifies the cosign release it installs, and picks the right `runner.arch`) and `anchore/sbom-action` (generates the SBOM from the registry digest). Anything added here joins the supply chain of every image we ship, so additions need a security argument.
+
+Two footguns if you touch them: `cosign-installer` has its own `v3.1.2` tag that is *not* "the installer for cosign 3.1.2" — always pin the SHA; and its `cosign-release` input requires a leading `v`. `anchore/sbom-action` defaults `upload-artifact` and `upload-release-assets` to `true`; both are disabled here so signing doesn't silently attach SBOMs to releases.

--- a/sign-oci/action.yml
+++ b/sign-oci/action.yml
@@ -1,0 +1,179 @@
+name: "Sign OCI Image (Cosign)"
+description: "Keyless-sign a pushed image by digest and attach an SBOM attestation. Signs every registry the digest was pushed to."
+
+# Must run in the SAME job as the push — it relies on the docker keychain the
+# caller already established. The calling JOB needs `permissions: id-token: write`
+# (composite actions cannot declare their own), plus `packages: write` for ghcr.io.
+#
+#   - id: build
+#     uses: docker/build-push-action@...
+#   - uses: odigos-io/ci-core/sign-oci@<sha>
+#     with:
+#       refs: us-central1-docker.pkg.dev/odigos-cloud/components/foo
+#       digest: ${{ steps.build.outputs.digest }}
+
+inputs:
+  refs:
+    description: >
+      Whitespace/newline-separated registry paths WITHOUT a tag or digest. Pass
+      every registry the digest went to — a signature lives beside the image in
+      one registry and does not travel with a copy.
+    required: true
+  digest:
+    description: "Image digest to sign. Use steps.<build>.outputs.digest."
+    required: true
+  recursive:
+    description: >
+      Sign child manifests as well as the index. Default true: everything here is
+      multi-arch and some consumers (COPY --from, crane pull --platform) resolve a
+      child rather than the index.
+    required: false
+    default: "true"
+  sbom:
+    description: "Generate an SBOM and attach it as an attestation."
+    required: false
+    default: "true"
+  sbom-type:
+    description: "cyclonedx or spdxjson."
+    required: false
+    default: "cyclonedx"
+  cosign-version:
+    description: "Pinned cosign version, no leading 'v'."
+    required: false
+    default: "3.1.2"
+  syft-version:
+    description: "Pinned syft version, no leading 'v'."
+    required: false
+    default: "1.50.0"
+  dry-run:
+    description: "Sign without uploading signatures or attestations."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      id: v
+      shell: bash
+      env:
+        REFS: ${{ inputs.refs }}
+        DIGEST: ${{ inputs.digest }}
+        SBOM_TYPE: ${{ inputs.sbom-type }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+          echo "::error::digest must be sha256:<64 hex>, got '$DIGEST'. Add an 'id:' to the build step and pass steps.<id>.outputs.digest."
+          exit 1
+        fi
+
+        # Newlines/CR to spaces, then word-split: drops blanks and indentation.
+        read -ra LIST <<< "$(tr '\n\r' '  ' <<< "$REFS")"
+        (( ${#LIST[@]} )) || { echo "::error::refs is empty."; exit 1; }
+
+        for ref in "${LIST[@]}"; do
+          # Only the last path segment can carry a tag; an earlier colon is a
+          # registry port and is legitimate.
+          if [[ "${ref##*/}" == *[:@]* ]]; then
+            echo "::error::refs must not contain a tag or digest, got '$ref'. Signing a mutable tag is a TOCTOU hole; pass the bare repository path."
+            exit 1
+          fi
+        done
+
+        case "$SBOM_TYPE" in
+          cyclonedx) echo "syft-format=cyclonedx-json" >> "$GITHUB_OUTPUT" ;;
+          spdxjson)  echo "syft-format=spdx-json"      >> "$GITHUB_OUTPUT" ;;
+          *) echo "::error::sbom-type must be cyclonedx or spdxjson, got '$SBOM_TYPE'."; exit 1 ;;
+        esac
+
+        echo "refs=${LIST[*]}"   >> "$GITHUB_OUTPUT"
+        echo "first=${LIST[0]}"  >> "$GITHUB_OUTPUT"
+
+    # Not a curl wrapper: pins a bootstrap cosign by SHA in its own SHA-pinned
+    # source, then uses it to `cosign verify-blob` the requested release. Also
+    # selects by runner.arch, which matters — the org runs arm64 release jobs.
+    # The leading 'v' is mandatory; a bare "3.1.2" fails its internal regex.
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        cosign-release: v${{ inputs.cosign-version }}
+
+    # Reads the digest straight from the registry using the caller's docker
+    # login. upload-artifact and upload-release-assets both default to TRUE and
+    # are disabled here — otherwise this would attach SBOMs to GitHub releases.
+    - name: Generate SBOM
+      if: ${{ inputs.sbom == 'true' }}
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: ${{ steps.v.outputs.first }}@${{ inputs.digest }}
+        format: ${{ steps.v.outputs.syft-format }}
+        output-file: sbom.json
+        syft-version: v${{ inputs.syft-version }}
+        upload-artifact: false
+        upload-release-assets: false
+
+    # Per-ref rather than `cosign sign ref1@d ref2@d ...`. Batching works, but
+    # cosign mints a fresh Fulcio cert and Rekor entry per ref either way, so the
+    # only difference is that a batch failure names the whole argument list
+    # instead of the ref that failed.
+    - name: Sign and attest
+      shell: bash
+      env:
+        REFS: ${{ steps.v.outputs.refs }}
+        DIGEST: ${{ inputs.digest }}
+        RECURSIVE: ${{ inputs.recursive }}
+        SBOM: ${{ inputs.sbom }}
+        SBOM_TYPE: ${{ inputs.sbom-type }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+
+        # Signing is fail-closed: an exhausted retry fails the publish job.
+        # The retry absorbs transient Fulcio/Rekor/registry blips so a
+        # seconds-long outage does not force anyone to reach for break-glass.
+        # Note `cosign sign` is not idempotent — a retry after a partial
+        # success can append a duplicate signature. That is harmless for
+        # verification (any one matching signature passes).
+        retry() {
+          local attempt=1 max=3 delay=5
+          until "$@"; do
+            if [[ $attempt -ge $max ]]; then
+              echo "::error::failed after ${max} attempts: $*"
+              return 1
+            fi
+            echo "::warning::attempt ${attempt} failed: $* — retrying in ${delay}s"
+            sleep "$delay"
+            delay=$((delay * 3))
+            attempt=$((attempt + 1))
+          done
+        }
+
+        SIGN=(cosign sign --yes)
+        if [[ "$RECURSIVE" == "true" ]]; then SIGN+=(--recursive); fi
+
+        # `cosign attest` has no --recursive; the attestation attaches to the
+        # index digest, the correct subject for an image-level SBOM. Note the
+        # SBOM itself describes one platform — syft resolves a single child of a
+        # multi-arch index. Per-platform SBOMs are tracked separately.
+        ATTEST=(cosign attest --yes --type "$SBOM_TYPE" --predicate sbom.json)
+
+        # cosign 3.x refuses to skip the registry upload unless it is given
+        # somewhere else to put the material: "--upload=false" and "--no-upload"
+        # both error without a local --bundle. A dry run therefore still mints a
+        # real Fulcio cert and signs — it just writes the bundle to disk instead
+        # of pushing it. (There is no --tlog-upload escape hatch under the
+        # default --use-signing-config.)
+        if [[ "$DRY_RUN" == "true" ]]; then
+          BUNDLE_DIR="$(mktemp -d)"
+          SIGN+=(--upload=false --bundle "${BUNDLE_DIR}/sign.bundle")
+          ATTEST+=(--no-upload --bundle "${BUNDLE_DIR}/attest.bundle")
+        fi
+
+        # shellcheck disable=SC2086 -- validated, whitespace-free list.
+        for ref in $REFS; do
+          echo "::group::$ref"
+          retry "${SIGN[@]}" "${ref}@${DIGEST}"
+          if [[ "$SBOM" == "true" ]]; then retry "${ATTEST[@]}" "${ref}@${DIGEST}"; fi
+          echo "::endgroup::"
+        done


### PR DESCRIPTION
Nothing in the org is signed today — no cosign, no SBOMs, no attestations. This is the first piece of that work: the reusable primitive, plus a way to test it. **No consumers are wired up here**, so merging this cannot affect a release.

## `sign-oci`

Composite action that keyless-signs an already-pushed image by digest and attaches a syft SBOM attestation.

Two deliberate constraints:

- **Digest only, never a tag.** Tags here are mutable — `:latest` moves on most publishes and RC digests get retagged to stable — so signing a tag is a TOCTOU hole. The action rejects a ref carrying one.
- **Takes a list of registry paths.** A signature lives beside the image in a single registry and does not survive a copy, so one build pushed to four registries needs four signatures.

It must run in the same job as the push, since it relies on the docker keychain the caller already established, and the calling job needs `id-token: write`.

Third-party dependencies are limited to `sigstore/cosign-installer` and `anchore/sbom-action`, both SHA-pinned. This action runs with `id-token: write` and the publish keychain, so anything it calls joins the supply chain of every image we ship. `actions/attest` was evaluated and rejected — it reads only the `auths` map from the docker config rather than `credHelpers`, so it cannot authenticate to Artifact Registry, and it caps `push-to-registry` at one subject.

## `test-sign-oci.yml`

Exercises the action end to end against a throwaway multi-arch image. It targets GHCR rather than Artifact Registry on purpose: auth is just `GITHUB_TOKEN`, so this needs no cloud secrets and no IAM change to run.

- feeds four invalid inputs and asserts each is rejected
- runs with `dry-run` and asserts nothing was signed
- signs for real, verifies the signature and that the SBOM attestation actually carries components
- verifies **both per-arch children** — the only assertion that proves `--recursive` did anything
- asserts verification **fails** for the wrong repo identity, the wrong workflow, the wrong OIDC issuer, and an attestation type never attested

That last group is the point. A `cosign verify` that passes proves very little on its own; if a signature from any workflow in the org satisfies the policy, there is no policy.

## Notes for review

- cosign 3.x deprecated `cosign copy` (now `oras copy -r`), `--tlog-upload=false`, and `verify --offline`. Flags here were checked against a real 3.1.2 binary rather than copied from examples.
- The SBOM describes one platform — syft resolves a single child of a multi-arch index. Per-platform SBOMs would be a behaviour change; left for later.
- Old untagged versions of the `ci-core-signing-test` package will accumulate in GHCR. I left cleanup out rather than grant the workflow `packages: delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)