### PR TITLE
RUN-1018 | fix(ci-core): skip PR policy checks on events without a pull request

### DIFF
--- a/require-linear/README.md
+++ b/require-linear/README.md
@@ -14,3 +14,19 @@ Ensures pull requests reference a Linear issue in the PR title, body, or branch 
 The check matches (case-insensitive) an allowed Linear team prefix followed by an issue number that does not start with `0`: `(CORE-|PLAT-|PRD-|RUN-|GEN-|DEVOPS-|SEC-)[1-9][0-9]*`.
 
 Bot accounts (`dependabot[bot]`, `renovate[bot]`, `odigos-bot`, `github-actions[bot]`, `keyval-release-bot`) and any PR opened by a Bot user are skipped. The allowed prefixes and skipped accounts are hardcoded in `action.yml`.
+
+## Merge queues
+
+Events other than `pull_request` and `pull_request_target` are skipped, since they carry no pull request to inspect.
+
+This matters when the check is required and the repository uses a merge queue. A queue entry fires `merge_group` against a `gh-readonly-queue/*` ref, so the workflow has to be triggered on it or the required check never reports and the queue stalls:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
+```
+
+Any job level condition reading `github.event.pull_request` also has to move to the step, since that context is null under `merge_group`.

--- a/require-linear/action.yml
+++ b/require-linear/action.yml
@@ -4,8 +4,29 @@ description: Ensures pull requests reference a Linear issue in the PR title, bod
 runs:
   using: composite
   steps:
+    - name: Skip when the event carries no pull request
+      id: context
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+
+        # merge_group runs against a gh-readonly-queue ref and carries no pull request
+        # payload, so title, body and branch all read as empty. Without this the pattern
+        # matches nothing and the check fails every queue entry instead of passing it.
+        # The policy is enforced on the pull_request events that run before the queue.
+        case "$EVENT_NAME" in
+          pull_request|pull_request_target) ;;
+          *)
+            echo "Event $EVENT_NAME carries no pull request - Linear check skipped."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            ;;
+        esac
+
     - name: Skip Linear check for bots
       id: bots
+      if: ${{ steps.context.outputs.skip != 'true' }}
       shell: bash
       env:
         PR_USER: ${{ github.event.pull_request.user.login }}
@@ -35,7 +56,7 @@ runs:
         done
 
     - name: Ensure PR links a Linear issue
-      if: ${{ steps.bots.outputs.skip != 'true' }}
+      if: ${{ steps.context.outputs.skip != 'true' && steps.bots.outputs.skip != 'true' }}
       shell: bash
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}

--- a/require-release-note/action.yml
+++ b/require-release-note/action.yml
@@ -10,14 +10,34 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Skip when the event carries no pull request
+      id: context
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+
+        # merge_group runs against a gh-readonly-queue ref and carries no pull request
+        # payload, so the body reads as empty, the release-note block is never found and
+        # the check fails. The policy is enforced on the pull_request events that run
+        # before the queue.
+        case "$EVENT_NAME" in
+          pull_request|pull_request_target) ;;
+          *)
+            echo "Event $EVENT_NAME carries no pull request - release note check skipped."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            ;;
+        esac
+
     - name: Skip release note check for bots
       shell: bash
-      if: ${{ github.event.pull_request.user.type == 'Bot' || contains(fromJson(inputs.bot-accounts-json), github.event.pull_request.user.login) }}
+      if: ${{ steps.context.outputs.skip != 'true' && (github.event.pull_request.user.type == 'Bot' || contains(fromJson(inputs.bot-accounts-json), github.event.pull_request.user.login)) }}
       run: echo "PR opened by ${{ github.event.pull_request.user.login }} - release note check skipped."
 
     - name: Check release note block
       shell: bash
-      if: ${{ github.event.pull_request.user.type != 'Bot' && !contains(fromJson(inputs.bot-accounts-json), github.event.pull_request.user.login) }}
+      if: ${{ steps.context.outputs.skip != 'true' && github.event.pull_request.user.type != 'Bot' && !contains(fromJson(inputs.bot-accounts-json), github.event.pull_request.user.login) }}
       env:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |


### PR DESCRIPTION
`merge_group` runs against a `gh-readonly-queue/*` ref and carries no pull request payload, so `github.event.pull_request.title`, `.body` and `.head.ref` all read as empty. Nothing matches the Linear pattern and the action exits 1.

That makes the current action a trap for any repo with a merge queue. When `require-linear` is a required check, the queue stalls at *"Expected — Waiting for status to be reported"* because the workflow is only triggered on `pull_request`. The obvious fix is adding the `merge_group` trigger — which today would turn a stalled queue into one that **rejects every entry**.

## Change

Skips any event other than `pull_request` / `pull_request_target`. There is no pull request to inspect once an entry is queued, and the policy is already enforced on the `pull_request` events that run before it.

The enforcement step now requires both guards. A skipped `bots` step leaves `steps.bots.outputs.skip` empty, so checking that alone would let it run.

## Consumers still need the trigger

This makes it *safe* to add `merge_group`, it does not add it. Each repo with a merge queue still needs:

```yaml
on:
  pull_request:
    types: [opened, edited, synchronize, reopened]
  merge_group:
    types: [checks_requested]
```

And any job-level `if` reading `github.event.pull_request` has to move to the step — that context is null under `merge_group`, where `!contains(null, …)` evaluates true and the job runs anyway.

Found via a stalled queue in `enterprise-go-instrumentation`, whose `pr-policy.yml` has exactly this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)