### PR TITLE
RUN-1047: verification policy, break-glass backfill, and signature drift check

### DIFF
--- a/.github/workflows/backfill-sign.yml
+++ b/.github/workflows/backfill-sign.yml
@@ -1,0 +1,108 @@
+name: Backfill Sign
+
+# Break-glass companion. Signing is fail-closed in every publish job; when
+# Sigstore or a registry is down mid-release, the documented escape is to ship
+# unsigned (deliberately, loudly) and make good afterwards. This workflow is
+# the "make good": it signs an image that is ALREADY in the registry, by
+# digest — cosign signs digests, and a digest does not change when tags are
+# applied or images are copied, so a backfill hours later produces exactly
+# the signature the release would have.
+#
+# Also usable to retroactively sign pre-rollout releases (e.g. the currently
+# deployed pins) before verify-gates go live anywhere.
+
+on:
+  workflow_dispatch:
+    inputs:
+      refs:
+        description: "Registry paths WITHOUT tag/digest, newline-separated (e.g. us-central1-docker.pkg.dev/odigos-cloud/components/odigos-odiglet)"
+        required: true
+        type: string
+      digest:
+        description: "Image digest to sign (sha256:...)"
+        required: true
+        type: string
+      reason:
+        description: "Why this is a backfill (outage link, release tag, ...). Recorded in the run for audit."
+        required: true
+        type: string
+      login-gcp:
+        description: "Authenticate to Artifact Registry (us-central1-docker.pkg.dev)"
+        type: boolean
+        default: true
+      login-dockerhub:
+        description: "Authenticate to Docker Hub"
+        type: boolean
+        default: false
+      login-ghcr:
+        description: "Authenticate to GHCR"
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # Fulcio cert for keyless signing (and GCP WIF when enabled)
+      packages: write   # only exercised when login-ghcr is true
+    steps:
+      - name: Record reason
+        env:
+          REASON: ${{ inputs.reason }}
+          DIGEST: ${{ inputs.digest }}
+        run: |
+          {
+            echo "## Backfill signing"
+            echo
+            echo "- digest: \`${DIGEST}\`"
+            echo "- reason: ${REASON}"
+            echo "- actor: ${GITHUB_ACTOR}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/checkout@v4
+
+      - id: gcp-auth
+        name: Authenticate with Google Cloud
+        if: ${{ inputs.login-gcp }}
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          access_token_lifetime: 1200s
+
+      - name: Login to Artifact Registry
+        if: ${{ inputs.login-gcp }}
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.login-dockerhub }}
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: ${{ inputs.login-ghcr }}
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # NOTE: the certificate identity of a backfill is THIS workflow
+      # (backfill-sign.yml), not the original publish workflow. The
+      # verification policy lists it as an accepted identity precisely so
+      # backfills are distinguishable from release-time signatures in audit.
+      - name: Sign
+        uses: ./sign-oci
+        with:
+          refs: ${{ inputs.refs }}
+          digest: ${{ inputs.digest }}

--- a/.github/workflows/backfill-sign.yml
+++ b/.github/workflows/backfill-sign.yml
@@ -62,7 +62,7 @@ jobs:
             echo "- actor: ${GITHUB_ACTOR}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - id: gcp-auth
         name: Authenticate with Google Cloud

--- a/.github/workflows/signature-drift-check.yml
+++ b/.github/workflows/signature-drift-check.yml
@@ -1,0 +1,124 @@
+name: Signature Drift Check
+
+# The dangerous signing failures are quiet: a copy that drops referrers, a
+# workflow someone edited, a break-glass release nobody backfilled. A green
+# release does not prove a signature exists. This walks recent tags of every
+# artifact in verification-policy.yaml and asserts each one carries a cosign
+# signature, so a silent regression surfaces within a day instead of when a
+# customer tries to verify.
+#
+# Only artifacts with a non-null `floor` are checked — tags older than the
+# floor are unsigned history, and artifacts with `floor: null` have not
+# started signing yet. Handles both signature layouts (OCI referrers API on
+# GAR, fallback tag schema on GHCR) by asking cosign, never by globbing for
+# .sig tags.
+
+on:
+  schedule:
+    - cron: "17 6 * * *" # daily, off the top of the hour
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  TAGS_TO_CHECK: "5" # most recent N tags per ref, newest first, floor-filtered
+  COSIGN_VERSION: "3.1.2"
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Check recent tags for missing signatures
+        id: check
+        run: |
+          set -uo pipefail
+
+          FAILED=""
+          SKIPPED=""
+          CHECKED=0
+
+          # Pull (name, floor, ref) triples out of the policy. Templated refs
+          # (<service>) are expanded from the services list.
+          # A policy parse failure must fail the check, not silently pass it.
+          ROWS_RAW=$(yq -r '
+            .artifacts[]
+            | select(.floor != null)
+            | .name as $n | .floor as $fl
+            | (.services // [null])[] as $svc
+            | .refs[]
+            | [$n, $fl, (. | sub("<service>", ($svc // "")))]
+            | @tsv' verification-policy.yaml) || {
+              echo "::error::failed to parse verification-policy.yaml"; exit 1; }
+          mapfile -t ROWS <<< "$ROWS_RAW"
+
+          if [ "${#ROWS[@]}" -eq 0 ]; then
+            echo "No artifacts have a signing floor set yet — nothing to check." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          for row in "${ROWS[@]}"; do
+            IFS=$'\t' read -r name floor ref <<< "$row"
+            # Private registries need auth this job does not have; check the
+            # public copies, which are what customers verify anyway.
+            case "$ref" in
+              *components-private*) SKIPPED="${SKIPPED}${ref} (private)\n"; continue ;;
+            esac
+
+            # Newest N version tags at or above the floor. sort -V puts the
+            # floor in order with the tags; everything after it qualifies.
+            tags=$(crane ls "$ref" 2>/dev/null \
+              | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' \
+              | sort -V \
+              | awk -v fl="$floor" '$0==fl{f=1} f{print}' \
+              | tail -n "$TAGS_TO_CHECK")
+            if [ -z "$tags" ]; then
+              SKIPPED="${SKIPPED}${ref} (no tags above floor ${floor})\n"
+              continue
+            fi
+
+            for tag in $tags; do
+              digest=$(crane digest "${ref}:${tag}" 2>/dev/null) || {
+                FAILED="${FAILED}${ref}:${tag} (digest unresolvable)\n"; continue; }
+              CHECKED=$((CHECKED + 1))
+              if cosign tree "${ref}@${digest}" 2>/dev/null | grep -q 'cosign/sign'; then
+                echo "ok   ${ref}:${tag}"
+              else
+                echo "MISS ${ref}:${tag} @${digest}"
+                FAILED="${FAILED}${ref}:${tag} @${digest}\n"
+              fi
+            done
+          done
+
+          {
+            echo "## Signature drift check"
+            echo
+            echo "- refs checked: ${CHECKED}"
+            if [ -n "$SKIPPED" ]; then echo "### Skipped"; printf '%b' "$SKIPPED" | sed 's/^/- /'; fi
+            if [ -n "$FAILED" ]; then echo "### MISSING SIGNATURES"; printf '%b' "$FAILED" | sed 's/^/- /'; fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$FAILED" ]; then
+            printf 'missing<<EOF\n%b\nEOF\n' "$FAILED" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Notify Slack on drift
+        if: failure()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with:
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "unused"
+          failure-description: "Signature drift check found published tags with NO cosign signature — see the run summary"
+          tag: drift-check

--- a/.github/workflows/signature-drift-check.yml
+++ b/.github/workflows/signature-drift-check.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -38,7 +38,7 @@ jobs:
           cosign-release: v3.1.2
 
       - name: Install crane
-        uses: imjasonh/setup-crane@v0.4
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Check recent tags for missing signatures
         id: check

--- a/README.md
+++ b/README.md
@@ -23,30 +23,8 @@
 4. [backfill-sign](./.github/workflows/backfill-sign.yml) — break-glass: sign an already-published digest after an outage forced an unsigned release
 5. [signature-drift-check](./.github/workflows/signature-drift-check.yml) — daily assertion that recent tags carry signatures
 
-### How image signing works
-
-Publish jobs call [sign-oci](./sign-oci/README.md) right after pushing an image. It signs
-**by digest** (never by tag) using keyless cosign: the job's GitHub OIDC token is traded
-for a short-lived certificate tied to the workflow's identity — no keys stored anywhere.
-
-The signature and a CycloneDX SBOM are uploaded **to the same registry, next to the
-image**, linked to its digest (they do not travel with `crane copy` — mirrors use
-`oras copy -r`). Each signing event is also recorded in the public Rekor transparency
-log, which is what lets the short-lived certificate verify forever.
-
-Consumers verify with the identity listed in [verification-policy.yaml](./verification-policy.yaml):
-
-```bash
-cosign verify \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '<identity from verification-policy.yaml>' \
-  <registry>/<image>@<digest>
-```
-
-Assurance is continuous: [signature-drift-check](./.github/workflows/signature-drift-check.yml)
-walks recent tags daily and alerts if anything above its signing floor is unsigned, and
-[backfill-sign](./.github/workflows/backfill-sign.yml) signs an already-published digest
-after an outage forced an unsigned release.
+### Supply-chain signing
+See [SIGNING.md](./SIGNING.md) — how signatures are made (keyless/Fulcio), where they live, and how to verify.
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@
 4. [backfill-sign](./.github/workflows/backfill-sign.yml) — break-glass: sign an already-published digest after an outage forced an unsigned release
 5. [signature-drift-check](./.github/workflows/signature-drift-check.yml) — daily assertion that recent tags carry signatures
 
+### How image signing works
+
+Publish jobs call [sign-oci](./sign-oci/README.md) right after pushing an image. It signs
+**by digest** (never by tag) using keyless cosign: the job's GitHub OIDC token is traded
+for a short-lived certificate tied to the workflow's identity — no keys stored anywhere.
+
+The signature and a CycloneDX SBOM are uploaded **to the same registry, next to the
+image**, linked to its digest (they do not travel with `crane copy` — mirrors use
+`oras copy -r`). Each signing event is also recorded in the public Rekor transparency
+log, which is what lets the short-lived certificate verify forever.
+
+Consumers verify with the identity listed in [verification-policy.yaml](./verification-policy.yaml):
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '<identity from verification-policy.yaml>' \
+  <registry>/<image>@<digest>
+```
+
+Assurance is continuous: [signature-drift-check](./.github/workflows/signature-drift-check.yml)
+walks recent tags daily and alerts if anything above its signing floor is unsigned, and
+[backfill-sign](./.github/workflows/backfill-sign.yml) signs an already-published digest
+after an outage forced an unsigned release.
+
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)
 2. [semver-info](./semver-info/README.md)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 ### Security and Supply Chain
 1. [vulnerabilities-scanner](./vulnerabilities-scanner/README.md)
 2. [sign-oci](./sign-oci/README.md) — keyless cosign signing and SBOM attestation for published images
+3. [verification-policy.yaml](./verification-policy.yaml) — per-artifact OIDC identities, signature locations, and signing floors
+4. [backfill-sign](./.github/workflows/backfill-sign.yml) — break-glass: sign an already-published digest after an outage forced an unsigned release
+5. [signature-drift-check](./.github/workflows/signature-drift-check.yml) — daily assertion that recent tags carry signatures
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -23,8 +23,7 @@ identity unnoticed.
 
 The signature and a CycloneDX SBOM are uploaded **to the same registry as the image**,
 linked to its digest (via the OCI referrers API, or a `sha256-<digest>` tag on
-registries without it). They do **not** travel with `crane copy` — mirrors use
-`oras copy -r`. Retags are free: everything hangs off the digest.
+registries without it).
 
 ## How to verify
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -45,4 +45,14 @@ minted by any workflow in the org, including PR CI.
   alerts on Slack if any recent tag above its signing floor lacks a signature
 - [backfill-sign](./.github/workflows/backfill-sign.yml) — signing is fail-closed, so a
   Sigstore outage means shipping unsigned on purpose; this signs the already-published
-  digest after the fact (digests don't change, so the result is identical)
+  digest after the fact
+
+### Retroactive signing
+
+Signing an old image is the same operation as signing a new one: a signature is a
+separate small artifact whose subject is the **digest**, uploaded next to the image —
+the image itself is never touched, and a referrer can be attached to an existing
+manifest at any time. The only difference is the certificate identity, which truthfully
+records `backfill-sign.yml` and *today's* Rekor timestamp — so a backfill always
+verifies, but audit can always tell it apart from a release-time signature. No
+backdating is possible.

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -1,0 +1,49 @@
+# Image signing at Odigos
+
+## How a signature is made
+
+Publish jobs call [sign-oci](./sign-oci/README.md) right after pushing an image, and
+sign **by digest** — never by tag, since tags are mutable. Keyless, per signature:
+
+1. cosign generates a **one-shot keypair in memory** — nothing is stored or rotated
+2. the job's GitHub **OIDC token** is exchanged at **Fulcio** (Sigstore's CA) for a
+   **~10-minute certificate** binding that public key to the workflow's identity
+   (`repo/workflow@ref`)
+3. the digest is signed with the ephemeral key
+4. signature + certificate are appended to **Rekor**, the public transparency log,
+   which returns a signed timestamp proving *when* the signing happened
+5. the private key is discarded
+
+The Rekor timestamp is what makes a 10-minute certificate verify forever: it proves
+the signature was created while the certificate was valid. Every signing event is
+public — auditable at search.sigstore.dev — so nobody can mint signatures with our
+identity unnoticed.
+
+## Where it lives
+
+The signature and a CycloneDX SBOM are uploaded **to the same registry as the image**,
+linked to its digest (via the OCI referrers API, or a `sha256-<digest>` tag on
+registries without it). They do **not** travel with `crane copy` — mirrors use
+`oras copy -r`. Retags are free: everything hangs off the digest.
+
+## How to verify
+
+Use the identity for the artifact from [verification-policy.yaml](./verification-policy.yaml):
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '<identity from verification-policy.yaml>' \
+  <registry>/<image>@<digest>
+```
+
+Never verify with a broad pattern like `.*odigos-io.*` — that would accept a signature
+minted by any workflow in the org, including PR CI.
+
+## Operations
+
+- [signature-drift-check](./.github/workflows/signature-drift-check.yml) — daily cron;
+  alerts on Slack if any recent tag above its signing floor lacks a signature
+- [backfill-sign](./.github/workflows/backfill-sign.yml) — signing is fail-closed, so a
+  Sigstore outage means shipping unsigned on purpose; this signs the already-published
+  digest after the fact (digests don't change, so the result is identical)

--- a/verification-policy.yaml
+++ b/verification-policy.yaml
@@ -45,7 +45,7 @@ artifacts:
     identity: '^https://github\.com/odigos-io/enterprise-go-instrumentation/\.github/workflows/offsets-push\.yml@refs/heads/.*$'
     refs:
       - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli-offsets
-    floor:  # first signed release, 2026-08-14, verified externally
+    floor: v1.34.3-f181968 # first signed release (2026-08-13); latest (v1.34.3-16e3399) verified externally incl. SBOM
     note: only :latest and :<cli-version>-<sha> tags are published, by design
 
   - name: odigos-vmagent-instrumentations

--- a/verification-policy.yaml
+++ b/verification-policy.yaml
@@ -1,0 +1,109 @@
+# Odigos signing verification policy.
+#
+# Machine-readable source of truth for HOW to verify every signed odigos
+# artifact: which OIDC identity signs it, where the signature lives, and from
+# which version signatures exist at all. Consumed by the signature-drift-check
+# workflow and by verification docs; customers verify with:
+#
+#   cosign verify \
+#     --certificate-oidc-issuer <issuer> \
+#     --certificate-identity-regexp '<identity>' \
+#     <ref>@<digest>
+#
+# Notes that shape the entries below:
+# - Identity is per repo AND per workflow, never a broad org pattern. A
+#   blanket `.*odigos-io.*` would accept a signature minted by any workflow
+#   in any org repo, including PR CI.
+# - dispatch-triggered workflows sign under refs/heads/<branch>; tag-triggered
+#   ones under refs/tags/<tag>. Some artifacts legitimately have both.
+# - Stable x.y.0 component images are same-repo retags of the RC digest, so
+#   they verify against the RC-tagged identity. That is correct, not a bug.
+# - `floor` is the first version from which signatures exist. Tags older than
+#   the floor are unsigned history. `floor: null` means signing has not
+#   shipped for this artifact yet — the drift check skips it.
+
+issuer: https://token.actions.githubusercontent.com
+sbom_type: cyclonedx
+
+# Every artifact below ALSO accepts this identity: signatures produced by the
+# break-glass backfill workflow (ci-core/backfill-sign.yml), which signs
+# already-published digests after an outage forced an unsigned release. The
+# distinct identity keeps backfills auditable — a release-time signature and a
+# backfill are never confusable.
+backfill_identity: '^https://github\.com/odigos-io/ci-core/\.github/workflows/backfill-sign\.yml@refs/heads/main$'
+
+artifacts:
+  - name: wasp-init
+    repo: odigos-io/ebpf-core
+    identity: '^https://github\.com/odigos-io/ebpf-core/\.github/workflows/build-sender\.yml@refs/(heads/main|heads/releases/.*|tags/.*)$'
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/wasp-init
+    floor: null # set when the signing PR merges and the first signed tag ships
+
+  - name: odigos-cli-offsets
+    repo: odigos-io/enterprise-go-instrumentation
+    identity: '^https://github\.com/odigos-io/enterprise-go-instrumentation/\.github/workflows/offsets-push\.yml@refs/heads/.*$'
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli-offsets
+    floor: null
+    note: only :latest and :<cli-version>-<sha> tags are published, by design
+
+  - name: odigos-vmagent-instrumentations
+    repo: odigos-io/vm-agent
+    identity: '^https://github\.com/odigos-io/vm-agent/\.github/workflows/publish-agents\.yml@refs/(heads/.*|tags/agents/.*)$'
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-vmagent-instrumentations
+      - us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-vmagent-instrumentations
+    floor: null
+
+  - name: odigos-components
+    repo: odigos-io/odigos
+    identity: '^https://github\.com/odigos-io/odigos/\.github/workflows/publish-modules\.yml@refs/tags/v.*$'
+    services: [autoscaler, scheduler, instrumentor, collector, odiglet, ui, operator, agents]
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-<service>
+      - us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-<service>
+      - docker.io/keyval/odigos-<service>
+      - ghcr.io/odigos-io/odigos-<service>
+    floor: null
+    note: >
+      x.y.0 stable tags are retags of the RC digest and verify against the
+      RC tag identity. The components-private mirror receives its signature
+      via `oras copy -r` at promotion.
+
+  - name: odigos-cli-image
+    repo: odigos-io/odigos
+    identity: '^https://github\.com/odigos-io/odigos/\.github/workflows/release\.yml@refs/heads/main$'
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli
+      - us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-cli
+      - docker.io/keyval/odigos-cli
+    floor: null
+    note: >
+      release.yml is dispatch-triggered only, so the certificate ref is
+      refs/heads/main, NOT a tag. Mirrors receive signatures via oras copy -r.
+
+  - name: odigos-victoria-metrics
+    repo: odigos-io/odigos
+    identity: '^https://github\.com/odigos-io/odigos/\.github/workflows/release\.yml@refs/heads/main$'
+    refs:
+      - docker.io/keyval/odigos-victoria-metrics
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-victoria-metrics
+      - us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-victoria-metrics
+    floor: null
+    note: >
+      RE-HOSTED upstream image. The signature attests that odigos published
+      this exact upstream digest under its name — not that odigos built it.
+
+  - name: odigos-enterprise-components
+    repo: odigos-io/odigos-enterprise
+    identity: '^https://github\.com/odigos-io/odigos-enterprise/\.github/workflows/release-images\.yml@refs/(tags/.*|heads/.*)$'
+    services: [odiglet, instrumentor, ui, collector, central-proxy, central-backend, central-ui, agents,
+               connector-runtime, connector-aws, connector-azure, connector-gcp]
+    refs:
+      - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-enterprise-<service>
+      - us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-enterprise-<service>
+      - docker.io/keyval/odigos-enterprise-<service>
+      - ghcr.io/odigos-io/odigos-enterprise-<service>
+    floor: null
+    note: odiglet and agents also publish -extended tag variants of separate digests.

--- a/verification-policy.yaml
+++ b/verification-policy.yaml
@@ -45,7 +45,7 @@ artifacts:
     identity: '^https://github\.com/odigos-io/enterprise-go-instrumentation/\.github/workflows/offsets-push\.yml@refs/heads/.*$'
     refs:
       - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli-offsets
-    floor: null
+    floor:  # first signed release, 2026-08-14, verified externally
     note: only :latest and :<cli-version>-<sha> tags are published, by design
 
   - name: odigos-vmagent-instrumentations


### PR DESCRIPTION
Three pieces that keep the signing rollout honest after the fact. Signing itself already ships (sign-oci, merged in #95); this adds the operations around it.

**`verification-policy.yaml`** — one file answering: *how do I verify artifact X?* Per artifact: which workflow identity signs it, which registries hold the signature, and from which version signatures exist (`floor`).

**`backfill-sign.yml`** — manual dispatch for outages. Signing is fail-closed, so if Sigstore is down you ship unsigned on purpose — then run this with the digest to sign it after the fact. Requires a `reason` input for audit.

**`signature-drift-check.yml`** — daily cron. Walks recent tags of every artifact with a `floor` set and alerts on Slack if any lacks a signature. Catches the quiet failures a green release hides.

All floors are `null` right now, so merging this is inert — the drift check does nothing until floors get set as artifacts ship their first signed releases.

```release-note
NONE
```