### PR TITLE
RUN-1051 | fix(vulnerabilities-scanner)!: drop results-json, always return the full report

### DIFF
--- a/vulnerabilities-scanner/action.yml
+++ b/vulnerabilities-scanner/action.yml
@@ -16,22 +16,8 @@ inputs:
     description: "Verbosity level for the summary (basic or detailed)"
     required: false
     default: "basic"
-  max-inline-bytes:
-    description: >-
-      Upper bound on the size of the results-json output. Reports larger than this are
-      omitted from results-json (it becomes '{}') because Actions cannot expand them in
-      an expression. results-file is unaffected.
-    required: false
-    default: "1000000"
 
 outputs:
-  results-json:
-    description: >-
-      The raw Grype scan results in JSON format.
-      Emitted only when the report is small enough to survive an Actions expression
-      (see max-inline-bytes); otherwise this is '{}' and you must use results-file.
-      Prefer results-file, which is always complete.
-    value: ${{ steps.process-results.outputs.results-json }}
   results-file:
     description: "Path to the raw Grype JSON results file. Always written, at any size."
     value: ${{ steps.process-results.outputs.results-file }}
@@ -102,7 +88,6 @@ runs:
       env:
         SEVERITY_CUTOFF_INPUT: ${{ inputs.severity-cutoff }}
         VERBOSITY: ${{ inputs.verbosity }}
-        MAX_INLINE_BYTES: ${{ inputs.max-inline-bytes }}
       run: |
         set -euo pipefail
 
@@ -120,25 +105,12 @@ runs:
           echo '{"matches":[]}' > "$JSON_FILE"
           echo "✅ No vulnerabilities found!" >> "$GITHUB_STEP_SUMMARY"
           {
-            echo "results-json={}"
             echo "total-count=0"
             echo "critical-count=0"
             echo "high-count=0"
             echo "cutoff-exceeded=false"
           } >> "$GITHUB_OUTPUT"
           exit 0
-        fi
-
-        # A large report cannot be round-tripped through an Actions expression: the
-        # workflow fails to template with "Maximum object size exceeded" and the
-        # consuming step silently receives an empty string. Skip the inline copy in
-        # that case and let callers read results-file instead.
-        RESULTS_BYTES="$(wc -c < "$JSON_FILE")"
-        if [ "$RESULTS_BYTES" -gt "${MAX_INLINE_BYTES:-1000000}" ]; then
-          echo "::warning::Grype report is ${RESULTS_BYTES} bytes, over the ${MAX_INLINE_BYTES:-1000000} byte inline limit. 'results-json' will be empty — read 'results-file' ($JSON_FILE) instead."
-          echo "results-json={}" >> "$GITHUB_OUTPUT"
-        else
-          echo "results-json=$(jq -c . "$JSON_FILE")" >> "$GITHUB_OUTPUT"
         fi
 
         SEVERITY_CUTOFF="$(echo "$SEVERITY_CUTOFF_INPUT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')"


### PR DESCRIPTION
⚠️ **Merge LAST.** Stacked on #97, and every consumer must migrate first.

## Why

`results-json` can never carry a large report — that isn't a tunable, it's a platform limit. A step output is expanded through an Actions expression, and a multi-megabyte value fails the whole step with `Maximum object size exceeded`. That's what made odiglet's 4.1 MB report silently become an empty file.

#97 added `max-inline-bytes` to avoid the crash, but that still leaves callers with `{}` above the threshold. Once every caller reads `results-file`, the inline path has no reason to exist — and removing it takes the size ceiling with it.

**Result: no byte limit anywhere.** `results-file` is written straight to disk and is always the complete report, at any size.

## Change

Removed:
- `results-json` output
- `max-inline-bytes` input and its `MAX_INLINE_BYTES` plumbing
- the whole size-guard branch

Surface after this:

| Inputs | Outputs |
|---|---|
| `image`, `path`, `severity-cutoff`, `verbosity` | `results-file`, `total-count`, `critical-count`, `high-count`, `cutoff-exceeded` |

Inputs are back to exactly what they were before #97.

## Testing

Re-ran the harness against real scan data with the inline path gone:

| Case | exit | counts | results-file |
|---|---|---|---|
| odiglet 4.1 MB, cutoff CRITICAL | 1 | 163 / 2 / 60 | ✅ |
| odiglet 4.1 MB, no cutoff | 0 | 163 / 2 / 60 | ✅ |
| autoscaler 48 KB, cutoff HIGH | 1 | 6 / 0 / 4 | ✅ |
| no report file | 0 | 0 / 0 / 0 | ✅ |

The 4.1 MB report now flows end to end with no cap involved.

## Merge order

1. #97 — adds `results-file`
2. odigos-io/odigos#5508 · odigos-io/odigos#5521 · odigos-io/odigos-enterprise#3438 — migrate all 16 call sites
3. **this PR** — removes `results-json`

Merging this before step 2 would resolve `results-json` to an empty string at every unmigrated call site and write empty artifacts — the original bug, everywhere at once.

Other consumers (dotnet, vm-agent, ui-kit, php, enterprise-go, java) only use the action for pass/fail and the job summary, never reading `results-json`, so they're unaffected.