### PR TITLE
CORE-1221 | feat: add semver-info action for Odigos release version fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)
-2. [cherry-pick](./cherry-pick/README.md)
-3. [dispatch-agent-version-update](./dispatch-agent-version-update/README.md)
-4. [apply-agent-version-update](./apply-agent-version-update/README.md)
+2. [semver-info](./semver-info/README.md)
+3. [cherry-pick](./cherry-pick/README.md)
+4. [dispatch-agent-version-update](./dispatch-agent-version-update/README.md)
+5. [apply-agent-version-update](./apply-agent-version-update/README.md)
 
 ### Release and Deployment Notifications
 1. [slack-release-notification](./.github/actions/slack-release-notification/README.md)

--- a/semver-info/README.md
+++ b/semver-info/README.md
@@ -1,0 +1,146 @@
+# Semver Info
+
+Reads git tags and origin `releases/*` branches and reports Odigos semantic version fields.
+
+Supported tag formats:
+
+| Kind | Example | Meaning |
+|------|---------|---------|
+| stable | `v1.21.4` | Published release (patch is kept) |
+| pre | `v1.22.0-pre3` | Pre-release of a not-yet-branched line |
+| rc | `v1.22.0-rc1` | Release candidate of a started line |
+
+Release branches are `releases/vX.Y.0`. Creating that branch (typically when an RC starts) marks the line as started even if no stable tag exists yet.
+
+## Field differences
+
+These are easy to confuse. They answer different questions. “Latest” / “last” / “highest” always means **highest by semver** (`v1.21.4` > `v1.21.0` > `v1.20.9`), never tag or commit time.
+
+| Output | Question it answers | Shape | Empty when |
+|--------|---------------------|-------|------------|
+| `latest_stable` | Highest **published** tag by semver | `vX.Y.Z` (patch kept) | No stable tags |
+| `last_release_line` | Highest **started** line by semver, published or not | `vX.Y.0` (always `.0`) | Never (errors if nothing exists) |
+| `last_release_branch` | Highest origin `releases/vX.Y.0` branch by semver | `releases/vX.Y.0` | Line is inferred from a tag only |
+| `next_release` | Next **unstarted** line (one minor after `last_release_line`). Used when cutting a new pre/rc from main — not for patches on an already-frozen line. | `vX.(Y+1).0` | Never |
+| `latest_pre` | Highest **existing** pre tag on `next_release`? | `vX.Y.0-preN` | No pres on that line |
+| `next_pre` | What pre tag should we **create** for `next_release`? | always set | Never |
+| `has_pre` | Does `latest_pre` exist? | `true` / `false` | n/a |
+| `latest_rc` / `next_rc` / `has_rc` | Same trio as pre, for `-rcN` on `next_release` | | |
+
+`next_pre` and `next_rc` are always computed against **`next_release`**, not `last_release_line`. Once `releases/v1.22.0` exists, pre/rc outputs move to `v1.23.0`.
+
+How `last_release_line` is chosen:
+
+1. Take `latest_stable`'s series (`v1.21.4` → `v1.21.0`).
+2. Take the highest origin `releases/vX.Y.0` branch.
+3. `last_release_line` is the max of those two. `next_release` is one minor after that.
+
+## Examples
+
+Repo state is on the left. Full outputs are on the right so the deltas are visible.
+
+### A. Only a published stable, no next line yet
+
+Tags: `v1.21.4`. Branches: none. No `v1.22.0-pre*` / `-rc*`.
+
+| Output | Value | Why |
+|--------|-------|-----|
+| `latest_stable` | `v1.21.4` | Highest published tag; patch kept |
+| `last_release_line` | `v1.21.0` | Same line, normalized to `.0` |
+| `last_release_branch` | *(empty)* | No `releases/*` branch on origin |
+| `next_release` | `v1.22.0` | One minor after `last_release_line` |
+| `latest_pre` | *(empty)* | No pres on 1.22 yet |
+| `next_pre` | `v1.22.0-pre0` | First pre of `next_release` |
+| `has_pre` | `false` | |
+| `latest_rc` | *(empty)* | |
+| `next_rc` | `v1.22.0-rc0` | |
+| `has_rc` | `false` | |
+
+`latest_stable` ≠ `last_release_line`: one is the tag (`v1.21.4`), the other is the line (`v1.21.0`).
+
+### B. Pres already exist for the next line (no release branch yet)
+
+Tags: `v1.21.4`, `v1.22.0-pre0`, `v1.22.0-pre2`. Branches: none.
+
+| Output | Value | Why |
+|--------|-------|-----|
+| `latest_stable` | `v1.21.4` | Unchanged — pres are not stable |
+| `last_release_line` | `v1.21.0` | 1.22 has no release branch, so it is not “started” |
+| `last_release_branch` | *(empty)* | |
+| `next_release` | `v1.22.0` | Still the line after 1.21 |
+| `latest_pre` | `v1.22.0-pre2` | Highest existing pre (not `pre0`) |
+| `next_pre` | `v1.22.0-pre3` | `pre(N+1)` of `latest_pre` |
+| `has_pre` | `true` | |
+| `next_rc` | `v1.22.0-rc0` | No rcs yet on 1.22 |
+
+`latest_pre` vs `next_pre`: what exists vs what to create. `last_release_line` stays on 1.21 because a pre tag does not open a release branch.
+
+### C. Release branch exists, stable not published yet (RC in progress)
+
+Tags: `v1.21.4`. Branches: `releases/v1.21.0`, `releases/v1.22.0`.
+
+| Output | Value | Why |
+|--------|-------|-----|
+| `latest_stable` | `v1.21.4` | 1.22 is not tagged stable |
+| `last_release_line` | `v1.22.0` | Unpublished branch is ahead of the stable tag |
+| `last_release_branch` | `releases/v1.22.0` | Highest origin release branch |
+| `next_release` | `v1.23.0` | One minor after the started 1.22 line |
+| `next_pre` | `v1.23.0-pre0` | Pres now target 1.23, not 1.22 |
+
+This is the gap between `latest_stable` and `last_release_line`: published vs started. Once the branch exists, `next_pre` skips that line.
+
+### D. RCs exist on the next line (no branch yet — unusual)
+
+Tags: `v1.21.4`, `v1.22.0-rc0`, `v1.22.0-rc1`. Branches: none.
+
+| Output | Value |
+|--------|-------|
+| `last_release_line` | `v1.21.0` |
+| `next_release` | `v1.22.0` |
+| `latest_rc` | `v1.22.0-rc1` |
+| `next_rc` | `v1.22.0-rc2` |
+| `has_rc` | `true` |
+| `next_pre` | `v1.22.0-pre0` |
+
+`has_rc` / `latest_rc` describe `next_release` only. Callers that must not emit a pre after an RC should check `has_rc` themselves; this action still reports `next_pre`.
+
+## Requirements
+
+The calling workflow must check out the repo with full tags (`fetch-depth: 0`). Origin must be reachable so `git ls-remote --heads origin 'releases/*'` can list release branches.
+
+When checkout uses `path:` (repo is not at the workspace root), pass that path as `directory`.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `directory` | no | `.` | Git working tree. Match `actions/checkout` `path:` when the repo is not at the workspace root. |
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v7
+  with:
+    fetch-depth: 0
+
+- name: Resolve semver
+  id: version
+  uses: odigos-io/ci-core/semver-info@main
+
+- run: echo "next pre is ${{ steps.version.outputs.next_pre }}"
+```
+
+Checkout into a subdirectory:
+
+```yaml
+- uses: actions/checkout@v7
+  with:
+    fetch-depth: 0
+    path: odigos
+
+- name: Resolve semver
+  id: version
+  uses: odigos-io/ci-core/semver-info@main
+  with:
+    directory: odigos
+```

--- a/semver-info/action.yml
+++ b/semver-info/action.yml
@@ -1,0 +1,129 @@
+name: Semver Info
+description: |
+  Reads git tags and origin release branches and outputs Odigos semantic
+  version fields. Repo must already be checked out with fetch-depth: 0.
+  Optional input directory is the git working tree (default: workspace root);
+  set it when checkout used path:.
+
+  latest_stable is the highest published vX.Y.Z tag (may be a patch).
+  last_release_line is the highest started vX.Y.0 line (from that tag's series
+  or a newer unpublished releases/vX.Y.0 branch). next_release is always
+  one minor after last_release_line. next_pre / next_rc are for next_release,
+  not last_release_line.
+
+  Example A — published v1.21.4, no 1.22 branch, no pres:
+    latest_stable=v1.21.4  last_release_line=v1.21.0  last_release_branch=
+    next_release=v1.22.0   latest_pre=  next_pre=v1.22.0-pre0  has_pre=false
+
+  Example B — same, but v1.22.0-pre2 already exists:
+    last_release_line=v1.21.0   next_release=v1.22.0
+    latest_pre=v1.22.0-pre2  next_pre=v1.22.0-pre3  has_pre=true
+
+  Example C — RC started: releases/v1.22.0 exists, stable still v1.21.4:
+    latest_stable=v1.21.4  last_release_line=v1.22.0
+    last_release_branch=releases/v1.22.0  next_release=v1.23.0
+    next_pre=v1.23.0-pre0  (1.22 is no longer the pre target)
+
+inputs:
+  directory:
+    description: |
+      Git working tree to inspect (relative to GITHUB_WORKSPACE, or absolute).
+      Required when actions/checkout used path: so the repo is not at the
+      workspace root. Defaults to the workspace root.
+    required: false
+    default: "."
+
+outputs:
+  latest_stable:
+    description: |
+      Highest published stable tag (vX.Y.Z). Empty if none exist.
+      Unlike last_release_line this keeps the patch (v1.21.4 not v1.21.0)
+      and ignores unpublished release branches.
+    value: ${{ steps.calc.outputs.latest_stable }}
+  last_release_line:
+    description: |
+      Highest started release line as vX.Y.0. Max of (1) latest_stable's
+      series and (2) the highest origin releases/vX.Y.0 branch, so an
+      unpublished line with a branch still wins. Not a git ref — see
+      last_release_branch for the branch name.
+    value: ${{ steps.calc.outputs.last_release_line }}
+  last_release_branch:
+    description: |
+      Git ref of the highest origin release branch (releases/vX.Y.0).
+      Empty when last_release_line is inferred only from a stable tag
+      (no releases/* branch on origin yet).
+    value: ${{ steps.calc.outputs.last_release_branch }}
+  next_release:
+    description: |
+      The line after last_release_line: vX.(Y+1).0. This is the series
+      next_pre and next_rc apply to, even if last_release_line is unpublished.
+    value: ${{ steps.calc.outputs.next_release }}
+  latest_pre:
+    description: |
+      Highest existing vX.Y.0-preN tag on next_release. Empty if none
+      (has_pre=false). What already exists — not what to create next
+      (that is next_pre).
+    value: ${{ steps.calc.outputs.latest_pre }}
+  next_pre:
+    description: |
+      Tag to create for the next pre of next_release: pre0 if latest_pre
+      is empty, otherwise pre(N+1). Always set; scoped to next_release,
+      never last_release_line.
+    value: ${{ steps.calc.outputs.next_pre }}
+  has_pre:
+    description: |
+      true if latest_pre is non-empty, else false. Convenience flag;
+      equivalent to testing whether latest_pre != ''.
+    value: ${{ steps.calc.outputs.has_pre }}
+  latest_rc:
+    description: |
+      Highest existing vX.Y.0-rcN tag on next_release. Empty if none
+      (has_rc=false). Counterpart of latest_pre for release candidates.
+    value: ${{ steps.calc.outputs.latest_rc }}
+  next_rc:
+    description: |
+      Tag to create for the next rc of next_release: rc0 if latest_rc
+      is empty, otherwise rc(N+1). Counterpart of next_pre.
+    value: ${{ steps.calc.outputs.next_rc }}
+  has_rc:
+    description: |
+      true if latest_rc is non-empty, else false. Counterpart of has_pre.
+    value: ${{ steps.calc.outputs.has_rc }}
+
+runs:
+  using: composite
+  steps:
+    - name: Calculate semver info
+      id: calc
+      shell: bash
+      working-directory: ${{ inputs.directory }}
+      env:
+        DIRECTORY: ${{ inputs.directory }}
+      run: node "${{ github.action_path }}/calculate.js"
+
+    - name: Write semver summary
+      shell: bash
+      env:
+        LATEST_STABLE: ${{ steps.calc.outputs.latest_stable }}
+        LAST_RELEASE_LINE: ${{ steps.calc.outputs.last_release_line }}
+        LAST_RELEASE_BRANCH: ${{ steps.calc.outputs.last_release_branch }}
+        NEXT_RELEASE: ${{ steps.calc.outputs.next_release }}
+        LATEST_PRE: ${{ steps.calc.outputs.latest_pre }}
+        NEXT_PRE: ${{ steps.calc.outputs.next_pre }}
+        LATEST_RC: ${{ steps.calc.outputs.latest_rc }}
+        NEXT_RC: ${{ steps.calc.outputs.next_rc }}
+      run: |
+        {
+          echo "## Semver info"
+          echo ""
+          echo "| Field | Value |"
+          echo "|-------|-------|"
+          echo "| Latest stable | \`${LATEST_STABLE:-'(none)'}\` |"
+          echo "| Last release line | \`${LAST_RELEASE_LINE}\` |"
+          echo "| Last release branch | \`${LAST_RELEASE_BRANCH:-'(none)'}\` |"
+          echo "| Next release | \`${NEXT_RELEASE}\` |"
+          echo "| Next pre | \`${NEXT_PRE}\` |"
+          echo "| Latest pre | \`${LATEST_PRE:-'(none)'}\` |"
+          echo "| Next rc | \`${NEXT_RC}\` |"
+          echo "| Latest rc | \`${LATEST_RC:-'(none)'}\` |"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/semver-info/calculate.js
+++ b/semver-info/calculate.js
@@ -1,0 +1,178 @@
+'use strict';
+
+// Reads git tags and origin release branches and reports Odigos semver fields.
+//
+// Tag formats:
+//   stable  vMAJOR.MINOR.PATCH
+//   pre     vMAJOR.MINOR.PATCH-preN
+//   rc      vMAJOR.MINOR.PATCH-rcN
+//
+// Release branches: releases/vMAJOR.MINOR.PATCH  (Odigos uses releases/vX.Y.0)
+//
+// last_release_line is the highest series among:
+//   - origin release branches (covers an unpublished line that already has a branch)
+//   - the latest stable tag's vMAJOR.MINOR.0
+// next_release is one minor after last_release_line (vX.(Y+1).0).
+// next_pre / next_rc are computed from tags of next_release.
+//
+// The repo must already be checked out with full tags (fetch-depth: 0).
+
+const { execSync: defaultExecSync } = require('child_process');
+const fs = require('fs');
+
+const STABLE_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
+const PRE_RE = /^v(\d+)\.(\d+)\.(\d+)-pre(\d+)$/;
+const RC_RE = /^v(\d+)\.(\d+)\.(\d+)-rc(\d+)$/;
+const BRANCH_RE = /(?:^|\/)releases\/v(\d+)\.(\d+)\.(\d+)$/;
+
+function parseStable(tag) {
+  const m = STABLE_RE.exec(tag);
+  if (!m) return null;
+  return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10), patch: parseInt(m[3], 10) };
+}
+
+function parsePre(tag) {
+  const m = PRE_RE.exec(tag);
+  if (!m) return null;
+  return {
+    major: parseInt(m[1], 10),
+    minor: parseInt(m[2], 10),
+    patch: parseInt(m[3], 10),
+    n: parseInt(m[4], 10),
+  };
+}
+
+function parseRc(tag) {
+  const m = RC_RE.exec(tag);
+  if (!m) return null;
+  return {
+    major: parseInt(m[1], 10),
+    minor: parseInt(m[2], 10),
+    patch: parseInt(m[3], 10),
+    n: parseInt(m[4], 10),
+  };
+}
+
+function fmt(major, minor, patch) {
+  return `v${major}.${minor}.${patch}`;
+}
+
+function cmpSeries(a, b) {
+  if (a.major !== b.major) return a.major - b.major;
+  return a.minor - b.minor;
+}
+
+function cmpStable(a, b) {
+  const series = cmpSeries(a, b);
+  if (series !== 0) return series;
+  return a.patch - b.patch;
+}
+
+function maxBy(items, cmp) {
+  return items.reduce((best, cur) => (cmp(cur, best) > 0 ? cur : best));
+}
+
+function calculate({ execSync = defaultExecSync, env = process.env } = {}) {
+  const GITHUB_OUTPUT = env.GITHUB_OUTPUT || '';
+  const directory = env.DIRECTORY || '.';
+
+  function git(cmd) {
+    return execSync(cmd, { encoding: 'utf8', cwd: directory }).trim();
+  }
+
+  let tagRaw = '';
+  try {
+    tagRaw = git('git tag -l');
+  } catch {
+    tagRaw = '';
+  }
+  const tags = tagRaw ? tagRaw.split('\n').filter(Boolean) : [];
+
+  let branchRaw = '';
+  try {
+    branchRaw = git("git ls-remote --heads origin 'releases/*'");
+  } catch {
+    branchRaw = '';
+  }
+
+  const branchVersions = [];
+  for (const line of branchRaw ? branchRaw.split('\n') : []) {
+    const ref = line.split(/[\s\t]+/)[1] || line;
+    const m = BRANCH_RE.exec(ref.trim());
+    if (!m) continue;
+    branchVersions.push({
+      major: parseInt(m[1], 10),
+      minor: parseInt(m[2], 10),
+      patch: parseInt(m[3], 10),
+    });
+  }
+
+  const stables = tags.map(parseStable).filter(Boolean).sort(cmpStable);
+  const latestStable = stables.length ? stables[stables.length - 1] : null;
+
+  const seriesCandidates = [...branchVersions];
+  if (latestStable) {
+    seriesCandidates.push({ major: latestStable.major, minor: latestStable.minor, patch: 0 });
+  }
+  if (seriesCandidates.length === 0) {
+    throw new Error('no stable tags or release branches found');
+  }
+
+  const lastRelease = maxBy(seriesCandidates, cmpSeries);
+  const nextRelease = { major: lastRelease.major, minor: lastRelease.minor + 1, patch: 0 };
+  const nextReleaseTag = fmt(nextRelease.major, nextRelease.minor, nextRelease.patch);
+
+  const pres = tags
+    .map(parsePre)
+    .filter((v) => v && v.major === nextRelease.major && v.minor === nextRelease.minor && v.patch === nextRelease.patch)
+    .sort((a, b) => a.n - b.n);
+  const rcs = tags
+    .map(parseRc)
+    .filter((v) => v && v.major === nextRelease.major && v.minor === nextRelease.minor && v.patch === nextRelease.patch)
+    .sort((a, b) => a.n - b.n);
+
+  const latestPre = pres.length ? `${nextReleaseTag}-pre${pres[pres.length - 1].n}` : '';
+  const nextPre = `${nextReleaseTag}-pre${pres.length ? pres[pres.length - 1].n + 1 : 0}`;
+  const latestRc = rcs.length ? `${nextReleaseTag}-rc${rcs[rcs.length - 1].n}` : '';
+  const nextRc = `${nextReleaseTag}-rc${rcs.length ? rcs[rcs.length - 1].n + 1 : 0}`;
+
+  const lastReleaseTag = fmt(lastRelease.major, lastRelease.minor, 0);
+  const lastBranch = branchVersions.length ? maxBy(branchVersions, cmpSeries) : null;
+  const lastReleaseBranch = lastBranch ? `releases/${fmt(lastBranch.major, lastBranch.minor, 0)}` : '';
+
+  const result = {
+    latest_stable: latestStable ? fmt(latestStable.major, latestStable.minor, latestStable.patch) : '',
+    last_release_line: lastReleaseTag,
+    last_release_branch: lastReleaseBranch,
+    next_release: nextReleaseTag,
+    latest_pre: latestPre,
+    next_pre: nextPre,
+    has_pre: pres.length > 0 ? 'true' : 'false',
+    latest_rc: latestRc,
+    next_rc: nextRc,
+    has_rc: rcs.length > 0 ? 'true' : 'false',
+  };
+
+  if (GITHUB_OUTPUT) {
+    const lines = Object.entries(result).map(([k, v]) => `${k}=${v}`).join('\n');
+    fs.appendFileSync(GITHUB_OUTPUT, lines + '\n');
+  }
+
+  return result;
+}
+
+if (require.main === module) {
+  try {
+    const r = calculate();
+    console.log(`latest_stable=${r.latest_stable}`);
+    console.log(`last_release_line=${r.last_release_line}  last_release_branch=${r.last_release_branch || '(none)'}`);
+    console.log(`next_release=${r.next_release}`);
+    console.log(`next_pre=${r.next_pre}  (latest_pre=${r.latest_pre || '(none)'})`);
+    console.log(`next_rc=${r.next_rc}  (latest_rc=${r.latest_rc || '(none)'})`);
+  } catch (e) {
+    console.error(`::error::${e.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { calculate };

--- a/semver-info/test.js
+++ b/semver-info/test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// Run with: node --test semver-info/test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { calculate } = require('./calculate');
+
+function makeExecSync({ tags = [], branches = [] } = {}) {
+  return (cmd, opts = {}) => {
+    if (cmd === 'git tag -l') {
+      return tags.join('\n');
+    }
+    if (cmd.includes('git ls-remote --heads origin')) {
+      return branches
+        .map((b) => {
+          const name = b.startsWith('releases/') ? b : `releases/${b}`;
+          return `abc123\trefs/heads/${name}`;
+        })
+        .join('\n');
+    }
+    throw new Error(`unexpected command: ${cmd} cwd=${opts.cwd}`);
+  };
+}
+
+function calc(tags, branches) {
+  return calculate({ execSync: makeExecSync({ tags, branches }) });
+}
+
+test('no tags and no branches → error', () => {
+  assert.throws(() => calc([], []), { message: /no stable tags or release branches/ });
+});
+
+test('latest stable v1.21.4, no release branches, no pres → v1.22.0-pre0', () => {
+  const r = calc(['v1.21.4', 'v1.21.3', 'v1.20.0']);
+  assert.equal(r.latest_stable, 'v1.21.4');
+  assert.equal(r.last_release_line, 'v1.21.0');
+  assert.equal(r.last_release_branch, '');
+  assert.equal(r.next_release, 'v1.22.0');
+  assert.equal(r.next_pre, 'v1.22.0-pre0');
+  assert.equal(r.latest_pre, '');
+  assert.equal(r.has_pre, 'false');
+  assert.equal(r.next_rc, 'v1.22.0-rc0');
+  assert.equal(r.has_rc, 'false');
+});
+
+test('existing pres on next release → increment pre number', () => {
+  const r = calc(['v1.21.4', 'v1.22.0-pre0', 'v1.22.0-pre2']);
+  assert.equal(r.next_release, 'v1.22.0');
+  assert.equal(r.latest_pre, 'v1.22.0-pre2');
+  assert.equal(r.next_pre, 'v1.22.0-pre3');
+  assert.equal(r.has_pre, 'true');
+});
+
+test('pre numbers increment numerically (pre9 → pre10)', () => {
+  const r = calc(['v1.21.0', 'v1.22.0-pre9']);
+  assert.equal(r.next_pre, 'v1.22.0-pre10');
+});
+
+test('unpublished release branch is last_release_line even without a stable tag', () => {
+  const r = calc(['v1.21.4'], ['releases/v1.22.0']);
+  assert.equal(r.latest_stable, 'v1.21.4');
+  assert.equal(r.last_release_line, 'v1.22.0');
+  assert.equal(r.last_release_branch, 'releases/v1.22.0');
+  assert.equal(r.next_release, 'v1.23.0');
+  assert.equal(r.next_pre, 'v1.23.0-pre0');
+});
+
+test('pres on the version after an unpublished release branch', () => {
+  const r = calc(['v1.21.4', 'v1.23.0-pre1'], ['releases/v1.22.0']);
+  assert.equal(r.last_release_line, 'v1.22.0');
+  assert.equal(r.next_release, 'v1.23.0');
+  assert.equal(r.latest_pre, 'v1.23.0-pre1');
+  assert.equal(r.next_pre, 'v1.23.0-pre2');
+});
+
+test('highest of multiple release branches wins', () => {
+  const r = calc(['v1.21.4'], ['releases/v1.21.0', 'releases/v1.22.0']);
+  assert.equal(r.last_release_line, 'v1.22.0');
+  assert.equal(r.last_release_branch, 'releases/v1.22.0');
+  assert.equal(r.next_release, 'v1.23.0');
+  assert.equal(r.next_pre, 'v1.23.0-pre0');
+});
+
+test('release branch older than latest stable does not go backwards', () => {
+  const r = calc(['v1.21.4'], ['releases/v1.21.0']);
+  assert.equal(r.last_release_line, 'v1.21.0');
+  assert.equal(r.next_release, 'v1.22.0');
+  assert.equal(r.next_pre, 'v1.22.0-pre0');
+});
+
+test('module tags and unrelated tags are ignored', () => {
+  const r = calc(['v1.21.4', 'common/v1.21.4', 'v1.22.0-beta1', 'v1.22.0-prefoo']);
+  assert.equal(r.latest_stable, 'v1.21.4');
+  assert.equal(r.next_pre, 'v1.22.0-pre0');
+});
+
+test('existing rc tags on next_release are reported', () => {
+  const r = calc(['v1.21.4', 'v1.22.0-rc0', 'v1.22.0-rc1']);
+  assert.equal(r.next_rc, 'v1.22.0-rc2');
+  assert.equal(r.latest_rc, 'v1.22.0-rc1');
+  assert.equal(r.has_rc, 'true');
+  assert.equal(r.next_pre, 'v1.22.0-pre0');
+});
+
+test('no stable tags, only a release branch', () => {
+  const r = calc([], ['releases/v1.22.0']);
+  assert.equal(r.latest_stable, '');
+  assert.equal(r.last_release_line, 'v1.22.0');
+  assert.equal(r.next_release, 'v1.23.0');
+  assert.equal(r.next_pre, 'v1.23.0-pre0');
+});
+
+test('git commands run in DIRECTORY', () => {
+  const seen = [];
+  const execSync = (cmd, opts = {}) => {
+    seen.push(opts.cwd);
+    return makeExecSync({ tags: ['v1.21.4'] })(cmd, opts);
+  };
+  calculate({ execSync, env: { DIRECTORY: '/tmp/odigos' } });
+  assert.ok(seen.length > 0);
+  assert.ok(seen.every((cwd) => cwd === '/tmp/odigos'));
+});


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a reusable `semver-info` GitHub Action that reads git tags and origin `releases/*` branches and reports Odigos version fields (latest stable, last/next release line, next pre/rc). This is the shared calculator for the forthcoming create-pre workflow in odigos ([CORE-1221](https://linear.app/odigos/issue/CORE-1221/ci-add-an-option-to-release-a-pre-release-from-a-given-brancehs)), so that version math lives in ci-core instead of being copied into each caller.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

```release-note
Add a semver-info GitHub Action that reports Odigos version fields (next pre/rc, last release line) from git tags and release branches.
```


Made with [Cursor](https://cursor.com)