### PR TITLE
RUN-1051: drift-check floors compare by version prefix, not full tag

### DIFF
--- a/.github/workflows/signature-drift-check.yml
+++ b/.github/workflows/signature-drift-check.yml
@@ -76,12 +76,18 @@ jobs:
               *components-private*) SKIPPED="${SKIPPED}${ref} (private)\n"; continue ;;
             esac
 
-            # Newest N version tags at or above the floor. sort -V puts the
-            # floor in order with the tags; everything after it qualifies.
+            # Newest N tags whose VERSION PREFIX is at or above the floor.
+            # Floors are bare versions (vX.Y.Z); tags may carry a -<sha> suffix,
+            # and git shas do not sort chronologically — anchoring on the full
+            # tag string would silently skip tags whose suffix sorts below the
+            # floor's, leaving unchecked blind spots.
             tags=$(crane ls "$ref" 2>/dev/null \
               | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' \
               | sort -V \
-              | awk -v fl="$floor" '$0==fl{f=1} f{print}' \
+              | while IFS= read -r t; do \
+                  v=${t%%-*}; \
+                  [ "$(printf '%s\n%s\n' "$floor" "$v" | sort -V | head -1)" = "$floor" ] && echo "$t"; \
+                done \
               | tail -n "$TAGS_TO_CHECK")
             if [ -z "$tags" ]; then
               SKIPPED="${SKIPPED}${ref} (no tags above floor ${floor})\n"

--- a/verification-policy.yaml
+++ b/verification-policy.yaml
@@ -18,9 +18,11 @@
 #   ones under refs/tags/<tag>. Some artifacts legitimately have both.
 # - Stable x.y.0 component images are same-repo retags of the RC digest, so
 #   they verify against the RC-tagged identity. That is correct, not a bug.
-# - `floor` is the first version from which signatures exist. Tags older than
-#   the floor are unsigned history. `floor: null` means signing has not
-#   shipped for this artifact yet — the drift check skips it.
+# - `floor` is the first version from which signatures exist, as a BARE
+#   version (vX.Y.Z, no suffix). Tags compare by their version prefix, so
+#   sha-suffixed builds of the floor version are all covered. Tags below the
+#   floor are unsigned history. `floor: null` means signing has not shipped
+#   for this artifact yet — the drift check skips it.
 
 issuer: https://token.actions.githubusercontent.com
 sbom_type: cyclonedx
@@ -45,7 +47,7 @@ artifacts:
     identity: '^https://github\.com/odigos-io/enterprise-go-instrumentation/\.github/workflows/offsets-push\.yml@refs/heads/.*$'
     refs:
       - us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli-offsets
-    floor: v1.34.3-f181968 # first signed release (2026-08-13); latest (v1.34.3-16e3399) verified externally incl. SBOM
+    floor: v1.34.3 # first signed releases 2026-08-13/14 (both v1.34.3-* builds), verified externally incl. SBOM
     note: only :latest and :<cli-version>-<sha> tags are published, by design
 
   - name: odigos-vmagent-instrumentations


### PR DESCRIPTION
First live run exposed a blind spot: floors anchored on the full tag with `sort -V`, and git-sha suffixes do not sort chronologically — so `v1.34.3-16e3399` and `v1.34.3-2274dfd` (both signed) sorted below the floor `v1.34.3-f181968` and were never checked. The check under-reports, which is exactly the wrong failure mode for the control meant to catch silent signing regressions.

Floors are now **bare versions** (`v1.34.3`) and tags qualify by version prefix. Tested against the live registry: all three signed cli-offsets builds qualify; the old logic caught one of three.

```release-note
NONE
```