### PR TITLE
RUN-1078: set the wasp-init signing floor after backfill

### DIFF
--- a/verification-policy.yaml
+++ b/verification-policy.yaml
@@ -40,7 +40,7 @@ artifacts:
     identity: '^https://github\.com/odigos-io/ebpf-core/\.github/workflows/build-sender\.yml@refs/(heads/main|heads/releases/.*|tags/.*)$'
     refs:
       - us-central1-docker.pkg.dev/odigos-cloud/components/wasp-init
-    floor: null # set when the signing PR merges and the first signed tag ships
+    floor: v0.0.6 # backfill-signed (RUN-1078); releases from v0.0.7 sign at build via build-sender.yml
 
   - name: odigos-cli-offsets
     repo: odigos-io/enterprise-go-instrumentation


### PR DESCRIPTION
The deployed wasp-init pins (`v0.0.6`, `v0.0.6-test`) were retroactively signed via `backfill-sign` (see RUN-1078), so the drift check can now watch wasp-init from `v0.0.6` onward. Verifiers accept the backfill identity per the policy; releases from v0.0.7 sign at build time.

Components/CLI/enterprise floors still wait for their first real signed release — a `v0.0.0-*` or backfilled-only floor there would flag all unsigned history.

```release-note
NONE
```