### PR TITLE
RUN-1081: backfill-sign runs state what they signed

### DIFF
--- a/.github/workflows/backfill-sign.yml
+++ b/.github/workflows/backfill-sign.yml
@@ -1,4 +1,7 @@
 name: Backfill Sign
+# The run list must say what each dispatch signed — a batch of backfills is
+# unreadable as "Manually run by <user>" xN.
+run-name: "Backfill Sign · ${{ inputs.refs }} @ ${{ inputs.digest }}"
 
 # Break-glass companion. Signing is fail-closed in every publish job; when
 # Sigstore or a registry is down mid-release, the documented escape is to ship


### PR DESCRIPTION
One-liner: `run-name` on Backfill Sign now includes the refs and digest, so the run list itself answers "which run signed what" — with a batch of ten dispatches today, every run read identically.

Multi-ref dispatches render the newline-separated refs flattened in the title; still unambiguous.

```release-note
NONE
```