### PR TITLE
RUN-1088 | feat(linear-release): add a Linear release sync action (backport to v1.4.x)

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -37,6 +37,7 @@ jobs:
       contents: read
     outputs:
       new_version: ${{ steps.calc.outputs.new_version }}
+      current_version: ${{ steps.calc.outputs.current_version }}
       create_branch: ${{ steps.calc.outputs.create_branch }}
       release_branch: ${{ steps.calc.outputs.release_branch }}
       base_branch: ${{ steps.normalize.outputs.base_branch }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -105,3 +105,29 @@ jobs:
           release_branch: ${{ needs.calculate.outputs.release_branch }}
           actor: ${{ github.actor }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  # ci-core files its own releases in Linear the same way it asks every other
+  # repo to. Its own job, not a step on `tag`: that keeps the third-party CLI
+  # away from the STS token, and keeps remote-action resolution — which happens
+  # during job setup, before continue-on-error applies — out of the job that
+  # cuts the tag.
+  linear-release:
+    needs: [calculate, tag]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.calculate.outputs.new_version }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: odigos-io/ci-core/linear-release@main
+        with:
+          access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ needs.calculate.outputs.new_version }}
+          # calculate.js reports v0.0.0 when the repo has no tags yet; that ref
+          # does not exist, so let Linear pick the scan base instead.
+          base-ref: ${{ needs.calculate.outputs.current_version != 'v0.0.0' && needs.calculate.outputs.current_version || '' }}

--- a/.github/workflows/test-linear-release.yml
+++ b/.github/workflows/test-linear-release.yml
@@ -1,0 +1,98 @@
+name: linear-release Test
+
+# Exercises the fail-soft contract, which is the whole reason this wrapper
+# exists. None of these cases need a real LINEAR_ACCESS_KEY.
+#
+# The bogus-key case is the one that matters: it lets the upstream action run
+# for real and fail against Linear, proving that `continue-on-error` on a
+# composite action's own step is honoured. If GitHub ever stops honouring it,
+# every caller silently starts failing its release job — this catches that.
+
+on:
+  pull_request:
+    paths:
+      - 'linear-release/**'
+      - '.github/workflows/test-linear-release.yml'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  fail-soft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: No access key is a skip, not a failure
+        id: no-key
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+
+      - name: No access key with fail-on-error is a failure
+        id: no-key-strict
+        continue-on-error: true
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+          fail-on-error: "true"
+
+      # A syntactically plausible key that Linear will reject. The upstream
+      # action downloads its CLI and really calls Linear here.
+      - name: A rejected key is swallowed
+        id: bad-key
+        uses: ./linear-release
+        with:
+          access-key: lin_pipeline_0000000000000000000000000000000000000000
+          version: v0.0.0-test
+
+      - name: A rejected key with fail-on-error surfaces
+        id: bad-key-strict
+        continue-on-error: true
+        uses: ./linear-release
+        with:
+          access-key: lin_pipeline_0000000000000000000000000000000000000000
+          version: v0.0.0-test
+          fail-on-error: "true"
+
+      - name: Assert each case behaved as documented
+        env:
+          NO_KEY: ${{ steps.no-key.outcome }}
+          NO_KEY_STRICT: ${{ steps.no-key-strict.outcome }}
+          BAD_KEY: ${{ steps.bad-key.outcome }}
+          BAD_KEY_STRICT: ${{ steps.bad-key-strict.outcome }}
+          NO_KEY_URL: ${{ steps.no-key.outputs.release-url }}
+        run: |
+          set -euo pipefail
+          rc=0
+
+          expect() {
+            local case="$1" want="$2" got="$3"
+            if [[ "$got" == "$want" ]]; then
+              echo "ok: $case -> $got"
+            else
+              echo "::error::$case expected outcome '$want' but got '$got'"
+              rc=1
+            fi
+          }
+
+          expect "no access key"                    success "$NO_KEY"
+          expect "no access key, fail-on-error"     failure "$NO_KEY_STRICT"
+          expect "rejected key"                     success "$BAD_KEY"
+          expect "rejected key, fail-on-error"      failure "$BAD_KEY_STRICT"
+
+          # The skip path must not invent outputs.
+          if [[ -n "$NO_KEY_URL" ]]; then
+            echo "::error::skip path returned a release-url ('$NO_KEY_URL'); it must be empty"
+            rc=1
+          else
+            echo "ok: skip path left release-url empty"
+          fi
+
+          exit $rc

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ### Release Management
 1. [tag-and-release](./tag-and-release/README.md)
+2. [linear-release](./linear-release/README.md) — record a published release and the issues it shipped in Linear
 
 ### Release and Deployment Notifications
 1. [slack-release-notification](./.github/actions/slack-release-notification/README.md)

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -1,0 +1,62 @@
+# linear-release
+
+Records a release in [Linear](https://linear.app) after it has been tagged and published. Wraps [`linear/linear-release-action`](https://github.com/linear/linear-release-action), which walks the commits in `<base-ref>..HEAD`, works out which Linear issues they belong to, and attaches those issues to a release named after the tag.
+
+The wrapper exists so the upstream pin lives in one place, and so a repo without a `LINEAR_ACCESS_KEY` skips instead of failing.
+
+## Usage
+
+Run it in its own job after the tagging job, with `continue-on-error` on the job:
+
+```yaml
+jobs:
+  linear-release:
+    needs: [calculate, tag]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.calculate.outputs.new_version }}
+          fetch-depth: 0       # required — the scan walks commit history
+          fetch-tags: true
+
+      - uses: odigos-io/ci-core/linear-release@main
+        with:
+          access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ needs.calculate.outputs.new_version }}
+          base-ref: ${{ needs.calculate.outputs.current_version }}
+```
+
+`base-ref` is optional but worth passing — it pins the commit range to exactly the previous release. Only pass a tag that exists; `tag-and-release` reports `v0.0.0` for a repo with no tags, so filter that out with `!= 'v0.0.0' && ... || ''`.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `access-key` | no | | Pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. Empty skips the sync |
+| `version` | yes | | Version the Linear release is named after, e.g. `v1.4.2` |
+| `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
+| `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
+| `dry-run` | no | `false` | Scan and read, but make no changes in Linear |
+| `fail-on-error` | no | `false` | Fail the step instead of warning when the sync cannot run |
+
+## Outputs
+
+`release-id`, `release-name`, `release-version`, `release-url`. All four are empty when nothing was created or updated — a skip, a failure, a `dry-run`, and a sync that matched no issues all look the same. Guard with `!= ''`.
+
+## Things that will bite you
+
+**The access key picks the pipeline, nothing here does.** A key belongs to exactly one pipeline, so a repo given the wrong key files its releases in someone else's. An org-wide `LINEAR_ACCESS_KEY` therefore sends every repo to the same pipeline; repos that need their own want a repo-level secret.
+
+**Give it its own job.** Two reasons: the third-party CLI it downloads should not run beside a release job's credentials, and the runner resolves remote actions during job *setup*, before `continue-on-error` can catch anything — in the tagging job that would fail the release outright.
+
+**Failures are otherwise swallowed.** This runs after the release is published, so a Linear problem warns rather than turning the job red. Look for the warning annotation. `fail-on-error: "true"` opts out; an unset secret is a warning either way.
+
+**Issue detection is broader than commit subjects.** Upstream matches branch names, magic words, `TEAM-123` keys, and the pull request a commit came from, so a squash-merge whose only link is `(#2173)` still resolves. No commit-convention change is needed.
+
+**The CLI is not pinned by digest.** The action is pinned to a commit SHA, but that commit downloads the `linear-release` binary from a mutable release tag with no checksum.
+
+See also [tag-and-release](../tag-and-release/README.md), which cuts the tag this action reports on.

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -1,0 +1,160 @@
+name: "Linear Release"
+description: "Sync a released tag into a Linear release pipeline, attaching the issues that shipped in it."
+
+# Runs AFTER the tag and the GitHub release exist. The sync walks the commits in
+# `<base-ref>..HEAD` and finds Linear issues through branch names, magic words,
+# issue keys in the subject, and the pull request a commit came from — so the
+# calling job must be sitting on the released commit with history
+# (`fetch-depth: 0`).
+#
+# Which Linear pipeline a release lands in is decided by the access key, not by
+# anything here — a pipeline access key belongs to exactly one pipeline.
+#
+# Fail-soft by design: by the time this runs the release is already published,
+# so a Linear outage — or a repo whose LINEAR_ACCESS_KEY is not provisioned yet
+# — warns and moves on instead of turning a shipped release red. Set
+# `fail-on-error: "true"` to opt out of that.
+#
+#   - uses: odigos-io/ci-core/linear-release@main
+#     with:
+#       access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
+#       version: ${{ needs.calculate.outputs.new_version }}
+#       base-ref: ${{ needs.calculate.outputs.current_version }}
+
+inputs:
+  access-key:
+    description: >
+      Linear pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. An unset
+      secret interpolates to an empty string rather than erroring, so an empty
+      value skips the sync — the usage snippet can be adopted in a repo before
+      anyone has provisioned the secret.
+    required: false
+    default: ""
+  version:
+    description: >
+      Version the Linear release is named after, e.g. `v1.4.2`. Pass it
+      explicitly — left empty, Linear names the release after the short commit
+      SHA instead, which is almost never what a tagged release wants.
+    required: true
+  base-ref:
+    description: >
+      Start of the commit scan, exclusive — `<base-ref>..HEAD`. Pass the
+      PREVIOUS release tag, and only if it exists: a ref that cannot be resolved
+      fails the scan. Left empty, Linear picks the base from its own record of
+      the last release.
+    required: false
+    default: ""
+  include-paths:
+    description: "Comma-separated globs restricting which commits count, e.g. `frontend/**,common/**`. For monorepos."
+    required: false
+    default: ""
+  dry-run:
+    description: "Scan commits and read from Linear, but skip the create/update mutations."
+    required: false
+    default: "false"
+  fail-on-error:
+    description: >
+      Fail the step when the sync cannot start or Linear rejects it. Default
+      false — see the fail-soft note above.
+    required: false
+    default: "false"
+
+outputs:
+  release-id:
+    description: "Linear release ID. Empty when nothing was created or updated."
+    value: ${{ steps.sync.outputs.release-id }}
+  release-name:
+    description: "Linear release name. Empty when nothing was created or updated."
+    value: ${{ steps.sync.outputs.release-name }}
+  release-version:
+    description: "Linear release version. Empty when nothing was created or updated."
+    value: ${{ steps.sync.outputs.release-version }}
+  release-url:
+    description: "URL of the Linear release. Empty when nothing was created or updated."
+    value: ${{ steps.sync.outputs.release-url }}
+
+runs:
+  using: composite
+  steps:
+
+    - name: Check for an access key
+      id: guard
+      shell: bash
+      env:
+        ACCESS_KEY: ${{ inputs.access-key }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [[ -n "${ACCESS_KEY}" ]]; then
+          exit 0
+        fi
+
+        MSG="linear-release: no access key, so ${VERSION:-this release} was not synced to Linear. Add the LINEAR_ACCESS_KEY secret and pass it as access-key."
+        if [[ "${FAIL_ON_ERROR}" == "true" ]]; then
+          echo "::error::${MSG}"
+          exit 1
+        fi
+
+        echo "::warning::${MSG}"
+        echo "skip=true" >> "$GITHUB_OUTPUT"
+
+    - name: Sync release to Linear
+      id: sync
+      if: steps.guard.outputs.skip != 'true'
+      # A literal `true`, deliberately, and not `${{ inputs.fail-on-error != 'true' }}`:
+      # the runner evaluates this key only after the wrapped action has run, by
+      # which point it has swapped the `inputs` context for the WRAPPED action's
+      # inputs — so any expression reading ours silently evaluates to null and the
+      # flag would be a no-op. Whether a failure is fatal is decided one step down.
+      continue-on-error: true
+      uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
+      with:
+        access_key: ${{ inputs.access-key }}
+        command: sync
+        version: ${{ inputs.version }}
+        base_ref: ${{ inputs.base-ref }}
+        include_paths: ${{ inputs.include-paths }}
+        dry_run: ${{ inputs.dry-run }}
+        # Pinned here rather than inherited: upstream's own cli_version default
+        # moves with the action version, and owning that pin in one place is the
+        # reason this wrapper exists.
+        cli_version: v0.15.0
+        log_level: ${{ runner.debug == '1' && 'verbose' || '' }}
+
+    - name: Report the outcome
+      # Skipped whenever the sync was — the guard has already had its say.
+      if: always() && steps.sync.outcome != 'skipped'
+      shell: bash
+      env:
+        OUTCOME: ${{ steps.sync.outcome }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        RELEASE_NAME: ${{ steps.sync.outputs.release-name }}
+        RELEASE_URL: ${{ steps.sync.outputs.release-url }}
+      run: |
+        set -euo pipefail
+
+        # `continue-on-error` above hides the red X, so this is where a failure
+        # becomes visible — and, if the caller asked for it, fatal.
+        if [[ "${OUTCOME}" != "success" ]]; then
+          MSG="linear-release: the Linear sync failed. The tag and the GitHub release are unaffected; re-run this job or add the release in Linear by hand."
+          if [[ "${FAIL_ON_ERROR}" == "true" ]]; then
+            echo "::error::${MSG}"
+            exit 1
+          fi
+          echo "::warning::${MSG}"
+          exit 0
+        fi
+
+        # dry-run, and a sync that matched no issues, both return without a URL.
+        if [[ -z "${RELEASE_URL}" ]]; then
+          echo "linear-release: no release was created or updated."
+          exit 0
+        fi
+
+        {
+          echo "### Linear release"
+          echo
+          echo "- [${RELEASE_NAME}](${RELEASE_URL})"
+        } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Backport of 76c8e09 (#107) to `releases/v1.4.x`. RUN-1088.

Two deviations from a clean cherry-pick, both forced by this branch being older than main:

- **README conflict.** v1.4.x has no `semver-info`, `cherry-pick`, or `*-agent-version-update`, so Release Management lists only `tag-and-release`. Resolved to that branch's reality — `linear-release` is item 2, not item 6.
- **Extra commit.** The backported job passes `calculate`'s `current_version` as `base-ref`, but v1.4.x's `calculate` job never exported it, so the scan base would have silently resolved to empty. One line added to fix it.

⚠️ #107 has not merged yet, so this backports an unmerged commit — if #107 changes in review, this diverges.
