### PR TITLE
RUN-1088 | fix(linear-release): drop a base-ref that is not an ancestor of HEAD

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -130,6 +130,6 @@ jobs:
         with:
           access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.calculate.outputs.new_version }}
-          # calculate.js reports v0.0.0 when the repo has no tags yet; that ref
-          # does not exist, so let Linear pick the scan base instead.
-          base-ref: ${{ needs.calculate.outputs.current_version != 'v0.0.0' && needs.calculate.outputs.current_version || '' }}
+          # The action drops this when it is not an ancestor of HEAD, which is
+          # what happens whenever the highest tag lives on a release branch.
+          base-ref: ${{ needs.calculate.outputs.current_version }}

--- a/.github/workflows/test-linear-release.yml
+++ b/.github/workflows/test-linear-release.yml
@@ -61,12 +61,23 @@ jobs:
           version: v0.0.0-test
           fail-on-error: "true"
 
+      # A tag that exists but lives on another branch is the shape that broke a
+      # real release: it must be dropped, not passed through and not fatal.
+      - name: A non-ancestor base-ref is dropped, not fatal
+        id: stray-base-ref
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+          base-ref: v1.4.2
+
       - name: Assert each case behaved as documented
         env:
           NO_KEY: ${{ steps.no-key.outcome }}
           NO_KEY_STRICT: ${{ steps.no-key-strict.outcome }}
           BAD_KEY: ${{ steps.bad-key.outcome }}
           BAD_KEY_STRICT: ${{ steps.bad-key-strict.outcome }}
+          STRAY_BASE_REF: ${{ steps.stray-base-ref.outcome }}
           NO_KEY_URL: ${{ steps.no-key.outputs.release-url }}
         run: |
           set -euo pipefail
@@ -86,6 +97,7 @@ jobs:
           expect "no access key, fail-on-error"     failure "$NO_KEY_STRICT"
           expect "rejected key"                     success "$BAD_KEY"
           expect "rejected key, fail-on-error"      failure "$BAD_KEY_STRICT"
+          expect "non-ancestor base-ref"            success "$STRAY_BASE_REF"
 
           # The skip path must not invent outputs.
           if [[ -n "$NO_KEY_URL" ]]; then

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -30,7 +30,7 @@ jobs:
           base-ref: ${{ needs.calculate.outputs.current_version }}
 ```
 
-`base-ref` is optional but worth passing — it pins the commit range to exactly the previous release. Only pass a tag that exists; `tag-and-release` reports `v0.0.0` for a repo with no tags, so filter that out with `!= 'v0.0.0' && ... || ''`.
+`base-ref` is optional but worth passing — it pins the commit range to exactly the previous release. Pass it unconditionally: it is dropped with a warning if it is unresolvable or not on this branch's history, which covers both `tag-and-release`'s `v0.0.0` placeholder and the common case below.
 
 ## Inputs
 
@@ -52,6 +52,8 @@ jobs:
 **The access key picks the pipeline, nothing here does.** A key belongs to exactly one pipeline, so a repo given the wrong key files its releases in someone else's. An org-wide `LINEAR_ACCESS_KEY` therefore sends every repo to the same pipeline; repos that need their own want a repo-level secret.
 
 **Give it its own job.** Two reasons: the third-party CLI it downloads should not run beside a release job's credentials, and the runner resolves remote actions during job *setup*, before `continue-on-error` can catch anything — in the tagging job that would fail the release outright.
+
+**`base-ref` is often not on your branch.** `tag-and-release` reports the highest tag by semver, which usually lives on a release branch — so a minor cut from the default branch gets a ref it cannot reach, and an unguarded scan fails outright. The action drops such a ref with a warning and lets Linear pick the baseline. It also needs `fetch-depth: 0` to resolve one at all.
 
 **Failures are otherwise swallowed.** This runs after the release is published, so a Linear problem warns rather than turning the job red. Look for the warning annotation. `fail-on-error: "true"` opts out; an unset secret is a warning either way.
 

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -39,9 +39,9 @@ inputs:
   base-ref:
     description: >
       Start of the commit scan, exclusive — `<base-ref>..HEAD`. Pass the
-      PREVIOUS release tag, and only if it exists: a ref that cannot be resolved
-      fails the scan. Left empty, Linear picks the base from its own record of
-      the last release.
+      PREVIOUS release tag; it is dropped with a warning if it is unresolvable
+      or not an ancestor of HEAD, so it is safe to pass unconditionally. Left
+      empty, Linear picks the base from its own record of the last release.
     required: false
     default: ""
   include-paths:
@@ -77,15 +77,27 @@ runs:
   using: composite
   steps:
 
-    - name: Check for an access key
+    - name: Validate inputs
       id: guard
       shell: bash
       env:
         ACCESS_KEY: ${{ inputs.access-key }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
         VERSION: ${{ inputs.version }}
+        BASE_REF: ${{ inputs.base-ref }}
       run: |
         set -euo pipefail
+
+        # A base-ref that is not on this branch's history makes the scan fail
+        # outright. That is the normal case, not an edge one: the highest tag by
+        # semver usually lives on a release branch, so a minor cut from the
+        # default branch gets handed a ref it cannot reach. Drop it and let
+        # Linear choose its own baseline rather than losing the whole sync.
+        if [[ -n "${BASE_REF}" ]] && ! git merge-base --is-ancestor "${BASE_REF}" HEAD 2>/dev/null; then
+          echo "::warning::linear-release: base-ref ${BASE_REF} is unresolvable or not an ancestor of HEAD; letting Linear choose the scan baseline."
+          BASE_REF=""
+        fi
+        echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
 
         if [[ -n "${ACCESS_KEY}" ]]; then
           exit 0
@@ -114,7 +126,7 @@ runs:
         access_key: ${{ inputs.access-key }}
         command: sync
         version: ${{ inputs.version }}
-        base_ref: ${{ inputs.base-ref }}
+        base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
         dry_run: ${{ inputs.dry-run }}
         # Pinned here rather than inherited: upstream's own cli_version default


### PR DESCRIPTION
The `v1.5.0` release ([run](https://github.com/odigos-io/ci-core/actions/runs/32363917912)) tagged and published fine, but its Linear sync failed and the fail-soft design swallowed it — green job, one warning:

```
Error: --base-ref v1.4.2 (b066a64) is not an ancestor of HEAD aa0c222.
```

`tag-and-release` reports `current_version` as the highest tag by semver, not the previous release *on this branch*. `v1.4.2` lives on `releases/v1.4.x`, so a minor cut from `main` got handed a ref it cannot reach. That is the normal case for any repo with an active release branch, not an edge one.

The action now drops a `base-ref` that is unresolvable or not an ancestor of HEAD, warns, and lets Linear pick the baseline — losing the scan-range pin instead of the whole sync. `base-ref` is therefore safe to pass unconditionally, so both call sites lose their `v0.0.0` special-case. RUN-1088.

`test-linear-release.yml` gains a case using `v1.4.2`, the exact shape that broke.

After merge, re-run the `linear-release` job on that run to backfill `v1.5.0` into Linear.
