### PR TITLE
RUN-1088 | feat(linear-release): detect plain issue keys and forward release notes (backport to v1.4.x)

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -125,8 +125,24 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Linear only auto-generates notes from the issues attached to a release,
+      # so hand it the notes GitHub already generated for this tag.
+      - name: Fetch the GitHub release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.calculate.outputs.new_version }}
+        run: |
+          set -uo pipefail
+          if ! gh release view "${VERSION}" --repo "${GITHUB_REPOSITORY}" \
+               --json body --jq .body > release-notes.md; then
+            echo "::warning::could not read the GitHub release notes for ${VERSION}"
+          fi
+          # Empty or missing is handled by the action: it warns and syncs without notes.
+          [ -s release-notes.md ] || rm -f release-notes.md
+
       - uses: odigos-io/ci-core/linear-release@main
         with:
+          release-notes: release-notes.md
           access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.calculate.outputs.new_version }}
           # The action drops this when it is not an ancestor of HEAD, which is

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -129,6 +129,6 @@ jobs:
         with:
           access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.calculate.outputs.new_version }}
-          # calculate.js reports v0.0.0 when the repo has no tags yet; that ref
-          # does not exist, so let Linear pick the scan base instead.
-          base-ref: ${{ needs.calculate.outputs.current_version != 'v0.0.0' && needs.calculate.outputs.current_version || '' }}
+          # The action drops this when it is not an ancestor of HEAD, which is
+          # what happens whenever the highest tag lives on a release branch.
+          base-ref: ${{ needs.calculate.outputs.current_version }}

--- a/.github/workflows/test-linear-release.yml
+++ b/.github/workflows/test-linear-release.yml
@@ -71,6 +71,14 @@ jobs:
           version: v0.0.0-test
           base-ref: v1.4.2
 
+      - name: A missing release-notes file is dropped, not fatal
+        id: stray-notes
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+          release-notes: does-not-exist.md
+
       - name: Assert each case behaved as documented
         env:
           NO_KEY: ${{ steps.no-key.outcome }}
@@ -78,6 +86,7 @@ jobs:
           BAD_KEY: ${{ steps.bad-key.outcome }}
           BAD_KEY_STRICT: ${{ steps.bad-key-strict.outcome }}
           STRAY_BASE_REF: ${{ steps.stray-base-ref.outcome }}
+          STRAY_NOTES: ${{ steps.stray-notes.outcome }}
           NO_KEY_URL: ${{ steps.no-key.outputs.release-url }}
         run: |
           set -euo pipefail
@@ -98,6 +107,7 @@ jobs:
           expect "rejected key"                     success "$BAD_KEY"
           expect "rejected key, fail-on-error"      failure "$BAD_KEY_STRICT"
           expect "non-ancestor base-ref"            success "$STRAY_BASE_REF"
+          expect "missing release-notes file"       success "$STRAY_NOTES"
 
           # The skip path must not invent outputs.
           if [[ -n "$NO_KEY_URL" ]]; then

--- a/.github/workflows/test-linear-release.yml
+++ b/.github/workflows/test-linear-release.yml
@@ -61,12 +61,23 @@ jobs:
           version: v0.0.0-test
           fail-on-error: "true"
 
+      # A tag that exists but lives on another branch is the shape that broke a
+      # real release: it must be dropped, not passed through and not fatal.
+      - name: A non-ancestor base-ref is dropped, not fatal
+        id: stray-base-ref
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+          base-ref: v1.4.2
+
       - name: Assert each case behaved as documented
         env:
           NO_KEY: ${{ steps.no-key.outcome }}
           NO_KEY_STRICT: ${{ steps.no-key-strict.outcome }}
           BAD_KEY: ${{ steps.bad-key.outcome }}
           BAD_KEY_STRICT: ${{ steps.bad-key-strict.outcome }}
+          STRAY_BASE_REF: ${{ steps.stray-base-ref.outcome }}
           NO_KEY_URL: ${{ steps.no-key.outputs.release-url }}
         run: |
           set -euo pipefail
@@ -86,6 +97,7 @@ jobs:
           expect "no access key, fail-on-error"     failure "$NO_KEY_STRICT"
           expect "rejected key"                     success "$BAD_KEY"
           expect "rejected key, fail-on-error"      failure "$BAD_KEY_STRICT"
+          expect "non-ancestor base-ref"            success "$STRAY_BASE_REF"
 
           # The skip path must not invent outputs.
           if [[ -n "$NO_KEY_URL" ]]; then

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -40,6 +40,8 @@ jobs:
 | `version` | yes | | Version the Linear release is named after, e.g. `v1.4.2` |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
+| `issue-pattern` | no | odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
+| `release-notes` | no | | Path to a markdown file to use as the release notes |
 | `dry-run` | no | `false` | Scan and read, but make no changes in Linear |
 | `fail-on-error` | no | `false` | Fail the step instead of warning when the sync cannot run |
 
@@ -57,7 +59,9 @@ jobs:
 
 **Failures are otherwise swallowed.** This runs after the release is published, so a Linear problem warns rather than turning the job red. Look for the warning annotation. `fail-on-error: "true"` opts out; an unset secret is a warning either way.
 
-**Issue detection is broader than commit subjects.** Upstream matches branch names, magic words, `TEAM-123` keys, and the pull request a commit came from, so a squash-merge whose only link is `(#2173)` still resolves. No commit-convention change is needed.
+**A bare issue key in a commit subject is NOT detected by default.** Upstream only matches a key preceded by a magic word (`fixes RUN-1`, `part of RUN-1`) or a `(#123)` pull request reference. `feat(x): thing (RUN-1)` matches nothing on its own — which is why `issue-pattern` defaults to the odigos team keys here. If you override it, keep the key in **capture group 1**; the pattern is applied to the subject only, never the body.
+
+**Zero issues means zero auto-generated notes.** Linear generates notes from the issues attached to a release, so a release that matched none shows nothing. Pass `release-notes` with a file — e.g. the body GitHub already generated for the tag — to have something either way.
 
 **The CLI is not pinned by digest.** The action is pinned to a commit SHA, but that commit downloads the `linear-release` binary from a mutable release tag with no checksum.
 

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -30,7 +30,7 @@ jobs:
           base-ref: ${{ needs.calculate.outputs.current_version }}
 ```
 
-`base-ref` is optional but worth passing — it pins the commit range to exactly the previous release. Only pass a tag that exists; `tag-and-release` reports `v0.0.0` for a repo with no tags, so filter that out with `!= 'v0.0.0' && ... || ''`.
+`base-ref` is optional but worth passing — it pins the commit range to exactly the previous release. Pass it unconditionally: it is dropped with a warning if it is unresolvable or not on this branch's history, which covers both `tag-and-release`'s `v0.0.0` placeholder and the common case below.
 
 ## Inputs
 
@@ -52,6 +52,8 @@ jobs:
 **The access key picks the pipeline, nothing here does.** A key belongs to exactly one pipeline, so a repo given the wrong key files its releases in someone else's. An org-wide `LINEAR_ACCESS_KEY` therefore sends every repo to the same pipeline; repos that need their own want a repo-level secret.
 
 **Give it its own job.** Two reasons: the third-party CLI it downloads should not run beside a release job's credentials, and the runner resolves remote actions during job *setup*, before `continue-on-error` can catch anything — in the tagging job that would fail the release outright.
+
+**`base-ref` is often not on your branch.** `tag-and-release` reports the highest tag by semver, which usually lives on a release branch — so a minor cut from the default branch gets a ref it cannot reach, and an unguarded scan fails outright. The action drops such a ref with a warning and lets Linear pick the baseline. It also needs `fetch-depth: 0` to resolve one at all.
 
 **Failures are otherwise swallowed.** This runs after the release is published, so a Linear problem warns rather than turning the job red. Look for the warning annotation. `fail-on-error: "true"` opts out; an unset secret is a warning either way.
 

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -39,9 +39,9 @@ inputs:
   base-ref:
     description: >
       Start of the commit scan, exclusive — `<base-ref>..HEAD`. Pass the
-      PREVIOUS release tag, and only if it exists: a ref that cannot be resolved
-      fails the scan. Left empty, Linear picks the base from its own record of
-      the last release.
+      PREVIOUS release tag; it is dropped with a warning if it is unresolvable
+      or not an ancestor of HEAD, so it is safe to pass unconditionally. Left
+      empty, Linear picks the base from its own record of the last release.
     required: false
     default: ""
   include-paths:
@@ -77,15 +77,27 @@ runs:
   using: composite
   steps:
 
-    - name: Check for an access key
+    - name: Validate inputs
       id: guard
       shell: bash
       env:
         ACCESS_KEY: ${{ inputs.access-key }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
         VERSION: ${{ inputs.version }}
+        BASE_REF: ${{ inputs.base-ref }}
       run: |
         set -euo pipefail
+
+        # A base-ref that is not on this branch's history makes the scan fail
+        # outright. That is the normal case, not an edge one: the highest tag by
+        # semver usually lives on a release branch, so a minor cut from the
+        # default branch gets handed a ref it cannot reach. Drop it and let
+        # Linear choose its own baseline rather than losing the whole sync.
+        if [[ -n "${BASE_REF}" ]] && ! git merge-base --is-ancestor "${BASE_REF}" HEAD 2>/dev/null; then
+          echo "::warning::linear-release: base-ref ${BASE_REF} is unresolvable or not an ancestor of HEAD; letting Linear choose the scan baseline."
+          BASE_REF=""
+        fi
+        echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
 
         if [[ -n "${ACCESS_KEY}" ]]; then
           exit 0
@@ -114,7 +126,7 @@ runs:
         access_key: ${{ inputs.access-key }}
         command: sync
         version: ${{ inputs.version }}
-        base_ref: ${{ inputs.base-ref }}
+        base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
         dry_run: ${{ inputs.dry-run }}
         # Pinned here rather than inherited: upstream's own cli_version default

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -2,10 +2,13 @@ name: "Linear Release"
 description: "Sync a released tag into a Linear release pipeline, attaching the issues that shipped in it."
 
 # Runs AFTER the tag and the GitHub release exist. The sync walks the commits in
-# `<base-ref>..HEAD` and finds Linear issues through branch names, magic words,
-# issue keys in the subject, and the pull request a commit came from — so the
-# calling job must be sitting on the released commit with history
-# (`fetch-depth: 0`).
+# `<base-ref>..HEAD`, so the calling job must be sitting on the released commit
+# with history (`fetch-depth: 0`).
+#
+# Out of the box the CLI only recognises an issue key preceded by a magic word
+# ("fixes RUN-1", "part of RUN-1") or a `(#123)` pull request reference. A key
+# sitting on its own in the subject is NOT detected — hence the `issue-pattern`
+# default below, which is what makes our usual `feat(x): thing (RUN-1)` link.
 #
 # Which Linear pipeline a release lands in is decided by the access key, not by
 # anything here — a pipeline access key belongs to exactly one pipeline.
@@ -48,6 +51,23 @@ inputs:
     description: "Comma-separated globs restricting which commits count, e.g. `frontend/**,common/**`. For monorepos."
     required: false
     default: ""
+  issue-pattern:
+    description: >
+      Regex whose FIRST capture group is a Linear issue key, matched against
+      commit subjects. Without this the CLI only detects keys preceded by a
+      magic word ("fixes RUN-1", "part of RUN-1"), so a bare or parenthesised
+      key is invisible — which is how most of our commits are written. The
+      default covers the odigos team keys.
+    required: false
+    default: '((?:CORE|PLAT|PRD|RUN|GEN|DEVOPS|SEC)-[0-9]+)'
+  release-notes:
+    description: >
+      Path to a markdown file whose contents become the release notes in
+      Linear. Linear only auto-generates notes from attached issues, so a
+      release that matched none has nothing to show without this. A missing
+      file is a warning, not an error.
+    required: false
+    default: ""
   dry-run:
     description: "Scan commits and read from Linear, but skip the create/update mutations."
     required: false
@@ -85,6 +105,7 @@ runs:
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
         VERSION: ${{ inputs.version }}
         BASE_REF: ${{ inputs.base-ref }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
       run: |
         set -euo pipefail
 
@@ -98,6 +119,13 @@ runs:
           BASE_REF=""
         fi
         echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+        # Losing the notes is not worth losing the sync over.
+        if [[ -n "${RELEASE_NOTES}" && ! -f "${RELEASE_NOTES}" ]]; then
+          echo "::warning::linear-release: release-notes file ${RELEASE_NOTES} does not exist; syncing without notes."
+          RELEASE_NOTES=""
+        fi
+        echo "release-notes=${RELEASE_NOTES}" >> "$GITHUB_OUTPUT"
 
         if [[ -n "${ACCESS_KEY}" ]]; then
           exit 0
@@ -128,6 +156,8 @@ runs:
         version: ${{ inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
+        issue_pattern: ${{ inputs.issue-pattern }}
+        release_notes: ${{ steps.guard.outputs.release-notes }}
         dry_run: ${{ inputs.dry-run }}
         # Pinned here rather than inherited: upstream's own cli_version default
         # moves with the action version, and owning that pin in one place is the


### PR DESCRIPTION
Backport of #111 to `releases/v1.4.x`. RUN-1088.

Two commits, because this branch had neither: the `base-ref` ancestor fix (#109, never backported here) and the `issue-pattern` / `release-notes` change (#111). Both cherry-picked clean; the resulting `linear-release/action.yml` is byte-identical to #111's.

Without these, every release cut from this branch syncs with zero issues and zero notes — the CLI only detects an issue key preceded by a magic word or a `(#123)` PR reference, so `feat(x): thing (RUN-1088)` links nothing.

Merge #111 first so `main` and the release branches don't diverge.
