### PR TITLE
RUN-1088 | fix(linear-release): cover every team key and name releases after the tag (backport to v1.4.x)

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           release-notes: release-notes.md
           access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          name: ${{ needs.calculate.outputs.new_version }}
           version: ${{ needs.calculate.outputs.new_version }}
           # The action drops this when it is not an ancestor of HEAD, which is
           # what happens whenever the highest tag lives on a release branch.

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -37,10 +37,11 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `access-key` | no | | Pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. Empty skips the sync |
-| `version` | yes | | Version the Linear release is named after, e.g. `v1.4.2` |
+| `version` | yes | | Version the release is keyed on, e.g. `v1.4.2` |
+| `name` | no | short SHA | Display name in Linear. Pass the tag, or releases read `3ba603d` |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
-| `issue-pattern` | no | odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
+| `issue-pattern` | no | all odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
 | `release-notes` | no | | Path to a markdown file to use as the release notes |
 | `dry-run` | no | `false` | Scan and read, but make no changes in Linear |
 | `fail-on-error` | no | `false` | Fail the step instead of warning when the sync cannot run |

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -39,6 +39,13 @@ inputs:
       explicitly — left empty, Linear names the release after the short commit
       SHA instead, which is almost never what a tagged release wants.
     required: true
+  name:
+    description: >
+      Display name for the release in Linear. Left empty the CLI names it after
+      the short commit SHA, so a release reads "3ba603d" rather than "v1.6.2".
+      Targeting is always by `version`, never by name.
+    required: false
+    default: ""
   base-ref:
     description: >
       Start of the commit scan, exclusive — `<base-ref>..HEAD`. Pass the
@@ -57,9 +64,10 @@ inputs:
       commit subjects. Without this the CLI only detects keys preceded by a
       magic word ("fixes RUN-1", "part of RUN-1"), so a bare or parenthesised
       key is invisible — which is how most of our commits are written. The
-      default covers the odigos team keys.
+      default covers every odigos team key; keep the key in capture group 1 if
+      you override it.
     required: false
-    default: '((?:CORE|PLAT|PRD|RUN|GEN|DEVOPS|SEC)-[0-9]+)'
+    default: '\b((?:DEVOPS|RUMBA|CORE|PLAT|PRD|RUN|GEN|SEC|DES)-[0-9]+)'
   release-notes:
     description: >
       Path to a markdown file whose contents become the release notes in
@@ -153,6 +161,7 @@ runs:
       with:
         access_key: ${{ inputs.access-key }}
         command: sync
+        name: ${{ inputs.name }}
         version: ${{ inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}


### PR DESCRIPTION
Backport of #114 to `releases/v1.4.x`. Clean cherry-pick; `linear-release/action.yml` is byte-identical to #114. RUN-1088.

Adds the two missing team keys (`RUMBA`, `DES`) plus a word boundary to the default `issue-pattern`, and a `name` input so releases read `v1.4.x` rather than a short SHA.
