### PR TITLE
RUN-1088 | feat(linear-release): show the tag as the title and the commit in the pill (backport to v1.5.x)

### DIFF
--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -37,8 +37,8 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `access-key` | no | | Pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. Empty skips the sync |
-| `version` | yes | | Version the release is keyed on, e.g. `v1.4.2` |
-| `name` | no | short SHA | Display name in Linear. Pass the tag, or releases read `3ba603d` |
+| `version` | yes | | The released tag, e.g. `v1.4.2`. Becomes the release title |
+| `name` | no | the tag | Overrides the title. Rarely needed |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
 | `issue-pattern` | no | all odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
@@ -51,6 +51,8 @@ jobs:
 `release-id`, `release-name`, `release-version`, `release-url`. All four are empty when nothing was created or updated — a skip, a failure, a `dry-run`, and a sync that matched no issues all look the same. Guard with `!= ''`.
 
 ## Things that will bite you
+
+**The tag is the title; the commit SHA is the pill.** `version` is also what a sync targets, so two tags on one commit resolve to a single release.
 
 **The access key picks the pipeline, nothing here does.** A key belongs to exactly one pipeline, so a repo given the wrong key files its releases in someone else's. An org-wide `LINEAR_ACCESS_KEY` therefore sends every repo to the same pipeline; repos that need their own want a repo-level secret.
 

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -35,15 +35,14 @@ inputs:
     default: ""
   version:
     description: >
-      Version the Linear release is named after, e.g. `v1.4.2`. Pass it
-      explicitly — left empty, Linear names the release after the short commit
-      SHA instead, which is almost never what a tagged release wants.
+      The released tag, e.g. `v1.4.2`. Becomes the release title; the pill
+      beside it carries the commit SHA. Two tags on one commit therefore
+      resolve to the same release.
     required: true
   name:
     description: >
-      Display name for the release in Linear. Left empty the CLI names it after
-      the short commit SHA, so a release reads "3ba603d" rather than "v1.6.2".
-      Targeting is always by `version`, never by name.
+      Overrides the release title. Defaults to `version` (the tag), which is
+      almost always what you want.
     required: false
     default: ""
   base-ref:
@@ -128,6 +127,9 @@ runs:
         fi
         echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
 
+        # Linear renders name as the title and version as the pill beside it.
+        echo "short-sha=$(git rev-parse --short HEAD 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+
         # Losing the notes is not worth losing the sync over.
         if [[ -n "${RELEASE_NOTES}" && ! -f "${RELEASE_NOTES}" ]]; then
           echo "::warning::linear-release: release-notes file ${RELEASE_NOTES} does not exist; syncing without notes."
@@ -161,8 +163,8 @@ runs:
       with:
         access_key: ${{ inputs.access-key }}
         command: sync
-        name: ${{ inputs.name }}
-        version: ${{ inputs.version }}
+        name: ${{ inputs.name != '' && inputs.name || inputs.version }}
+        version: ${{ steps.guard.outputs.short-sha != '' && steps.guard.outputs.short-sha || inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
         issue_pattern: ${{ inputs.issue-pattern }}


### PR DESCRIPTION
Backport of #117 to `releases/v1.5.x`. Clean cherry-pick, `action.yml` byte-identical. RUN-1088.
