### PR TITLE
RUN-1088 | fix(linear-release): team keys and commit-in-pill (backport to v1.6.x)

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -145,6 +145,7 @@ jobs:
         with:
           release-notes: release-notes.md
           access-key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          name: ${{ needs.calculate.outputs.new_version }}
           version: ${{ needs.calculate.outputs.new_version }}
           # The action drops this when it is not an ancestor of HEAD, which is
           # what happens whenever the highest tag lives on a release branch.

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -37,8 +37,8 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `access-key` | no | | Pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. Empty skips the sync |
-| `version` | yes | | Version the release is keyed on, e.g. `v1.4.2` |
-| `name` | no | short SHA | Display name in Linear. Pass the tag, or releases read `3ba603d` |
+| `version` | yes | | The released tag, e.g. `v1.4.2`. Becomes the release title |
+| `name` | no | the tag | Overrides the title. Rarely needed |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
 | `issue-pattern` | no | all odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
@@ -51,6 +51,8 @@ jobs:
 `release-id`, `release-name`, `release-version`, `release-url`. All four are empty when nothing was created or updated — a skip, a failure, a `dry-run`, and a sync that matched no issues all look the same. Guard with `!= ''`.
 
 ## Things that will bite you
+
+**The tag is the title; the commit SHA is the pill.** `version` is also what a sync targets, so two tags on one commit resolve to a single release.
 
 **The access key picks the pipeline, nothing here does.** A key belongs to exactly one pipeline, so a repo given the wrong key files its releases in someone else's. An org-wide `LINEAR_ACCESS_KEY` therefore sends every repo to the same pipeline; repos that need their own want a repo-level secret.
 

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -37,10 +37,11 @@ jobs:
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `access-key` | no | | Pipeline access key, normally `secrets.LINEAR_ACCESS_KEY`. Empty skips the sync |
-| `version` | yes | | Version the Linear release is named after, e.g. `v1.4.2` |
+| `version` | yes | | Version the release is keyed on, e.g. `v1.4.2` |
+| `name` | no | short SHA | Display name in Linear. Pass the tag, or releases read `3ba603d` |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
-| `issue-pattern` | no | odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
+| `issue-pattern` | no | all odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
 | `release-notes` | no | | Path to a markdown file to use as the release notes |
 | `dry-run` | no | `false` | Scan and read, but make no changes in Linear |
 | `fail-on-error` | no | `false` | Fail the step instead of warning when the sync cannot run |

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -35,15 +35,14 @@ inputs:
     default: ""
   version:
     description: >
-      Version the Linear release is named after, e.g. `v1.4.2`. Pass it
-      explicitly — left empty, Linear names the release after the short commit
-      SHA instead, which is almost never what a tagged release wants.
+      The released tag, e.g. `v1.4.2`. Becomes the release title; the pill
+      beside it carries the commit SHA. Two tags on one commit therefore
+      resolve to the same release.
     required: true
   name:
     description: >
-      Display name for the release in Linear. Left empty the CLI names it after
-      the short commit SHA, so a release reads "3ba603d" rather than "v1.6.2".
-      Targeting is always by `version`, never by name.
+      Overrides the release title. Defaults to `version` (the tag), which is
+      almost always what you want.
     required: false
     default: ""
   base-ref:
@@ -128,6 +127,9 @@ runs:
         fi
         echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
 
+        # Linear renders name as the title and version as the pill beside it.
+        echo "short-sha=$(git rev-parse --short HEAD 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+
         # Losing the notes is not worth losing the sync over.
         if [[ -n "${RELEASE_NOTES}" && ! -f "${RELEASE_NOTES}" ]]; then
           echo "::warning::linear-release: release-notes file ${RELEASE_NOTES} does not exist; syncing without notes."
@@ -161,8 +163,8 @@ runs:
       with:
         access_key: ${{ inputs.access-key }}
         command: sync
-        name: ${{ inputs.name }}
-        version: ${{ inputs.version }}
+        name: ${{ inputs.name != '' && inputs.name || inputs.version }}
+        version: ${{ steps.guard.outputs.short-sha != '' && steps.guard.outputs.short-sha || inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
         issue_pattern: ${{ inputs.issue-pattern }}

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -39,6 +39,13 @@ inputs:
       explicitly — left empty, Linear names the release after the short commit
       SHA instead, which is almost never what a tagged release wants.
     required: true
+  name:
+    description: >
+      Display name for the release in Linear. Left empty the CLI names it after
+      the short commit SHA, so a release reads "3ba603d" rather than "v1.6.2".
+      Targeting is always by `version`, never by name.
+    required: false
+    default: ""
   base-ref:
     description: >
       Start of the commit scan, exclusive — `<base-ref>..HEAD`. Pass the
@@ -57,9 +64,10 @@ inputs:
       commit subjects. Without this the CLI only detects keys preceded by a
       magic word ("fixes RUN-1", "part of RUN-1"), so a bare or parenthesised
       key is invisible — which is how most of our commits are written. The
-      default covers the odigos team keys.
+      default covers every odigos team key; keep the key in capture group 1 if
+      you override it.
     required: false
-    default: '((?:CORE|PLAT|PRD|RUN|GEN|DEVOPS|SEC)-[0-9]+)'
+    default: '\b((?:DEVOPS|RUMBA|CORE|PLAT|PRD|RUN|GEN|SEC|DES)-[0-9]+)'
   release-notes:
     description: >
       Path to a markdown file whose contents become the release notes in
@@ -153,6 +161,7 @@ runs:
       with:
         access_key: ${{ inputs.access-key }}
         command: sync
+        name: ${{ inputs.name }}
         version: ${{ inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}


### PR DESCRIPTION
Backport of #114 and #117 to `releases/v1.6.x`, which branched before either. Both clean cherry-picks, `action.yml` byte-identical to main. RUN-1088.

Adds the two missing team keys (`RUMBA`, `DES`) plus a word boundary, and makes the tag the release title with the commit SHA in the pill.
