### PR TITLE
RUN-1088 | fix(linear-release): scan from the fork point when base-ref is off-branch (backport to v1.4.x)

### DIFF
--- a/.github/workflows/test-linear-release.yml
+++ b/.github/workflows/test-linear-release.yml
@@ -62,14 +62,22 @@ jobs:
           fail-on-error: "true"
 
       # A tag that exists but lives on another branch is the shape that broke a
-      # real release: it must be dropped, not passed through and not fatal.
-      - name: A non-ancestor base-ref is dropped, not fatal
+      # real release: it must resolve to the fork point, not fail.
+      - name: A non-ancestor base-ref resolves to the fork point
         id: stray-base-ref
         uses: ./linear-release
         with:
           access-key: ""
           version: v0.0.0-test
           base-ref: v1.4.2
+
+      - name: An unresolvable base-ref is dropped, not fatal
+        id: bogus-base-ref
+        uses: ./linear-release
+        with:
+          access-key: ""
+          version: v0.0.0-test
+          base-ref: no-such-ref-anywhere
 
       - name: A missing release-notes file is dropped, not fatal
         id: stray-notes
@@ -87,6 +95,7 @@ jobs:
           BAD_KEY_STRICT: ${{ steps.bad-key-strict.outcome }}
           STRAY_BASE_REF: ${{ steps.stray-base-ref.outcome }}
           STRAY_NOTES: ${{ steps.stray-notes.outcome }}
+          BOGUS_BASE_REF: ${{ steps.bogus-base-ref.outcome }}
           NO_KEY_URL: ${{ steps.no-key.outputs.release-url }}
         run: |
           set -euo pipefail
@@ -108,6 +117,7 @@ jobs:
           expect "rejected key, fail-on-error"      failure "$BAD_KEY_STRICT"
           expect "non-ancestor base-ref"            success "$STRAY_BASE_REF"
           expect "missing release-notes file"       success "$STRAY_NOTES"
+          expect "unresolvable base-ref"            success "$BOGUS_BASE_REF"
 
           # The skip path must not invent outputs.
           if [[ -n "$NO_KEY_URL" ]]; then

--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -58,6 +58,8 @@ jobs:
 
 **Give it its own job.** Two reasons: the third-party CLI it downloads should not run beside a release job's credentials, and the runner resolves remote actions during job *setup*, before `continue-on-error` can catch anything — in the tagging job that would fail the release outright.
 
+**`base-ref` is resolved to the fork point when it is not an ancestor.** The highest tag by semver usually lives on a release branch, so a minor cut from the default branch is handed a ref it cannot reach; scanning `<merge-base>..HEAD` gives exactly what this release ships that the last one did not.
+
 **`base-ref` is often not on your branch.** `tag-and-release` reports the highest tag by semver, which usually lives on a release branch — so a minor cut from the default branch gets a ref it cannot reach, and an unguarded scan fails outright. The action drops such a ref with a warning and lets Linear pick the baseline. It also needs `fetch-depth: 0` to resolve one at all.
 
 **Failures are otherwise swallowed.** This runs after the release is published, so a Linear problem warns rather than turning the job red. Look for the warning annotation. `fail-on-error: "true"` opts out; an unset secret is a warning either way.

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -116,14 +116,21 @@ runs:
       run: |
         set -euo pipefail
 
-        # A base-ref that is not on this branch's history makes the scan fail
-        # outright. That is the normal case, not an edge one: the highest tag by
-        # semver usually lives on a release branch, so a minor cut from the
-        # default branch gets handed a ref it cannot reach. Drop it and let
-        # Linear choose its own baseline rather than losing the whole sync.
+        # The caller passes the highest tag by semver, which for a minor cut from
+        # the default branch lives on a release branch and is therefore not an
+        # ancestor of HEAD. Scanning from it fails outright, so resolve it to the
+        # fork point instead: <merge-base>..HEAD is everything this release ships
+        # that the previous one did not. On a release branch the ref is already an
+        # ancestor and merge-base returns it unchanged.
         if [[ -n "${BASE_REF}" ]] && ! git merge-base --is-ancestor "${BASE_REF}" HEAD 2>/dev/null; then
-          echo "::warning::linear-release: base-ref ${BASE_REF} is unresolvable or not an ancestor of HEAD; letting Linear choose the scan baseline."
-          BASE_REF=""
+          FORK_POINT="$(git merge-base "${BASE_REF}" HEAD 2>/dev/null || true)"
+          if [[ -n "${FORK_POINT}" ]]; then
+            echo "::notice::linear-release: base-ref ${BASE_REF} is not an ancestor of HEAD; scanning from the fork point ${FORK_POINT} instead."
+            BASE_REF="${FORK_POINT}"
+          else
+            echo "::warning::linear-release: base-ref ${BASE_REF} is unresolvable; letting Linear choose the scan baseline."
+            BASE_REF=""
+          fi
         fi
         echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Backport of #121 to `releases/v1.4.x`. Clean cherry-pick, `action.yml` byte-identical. RUN-1088.

Scans from the fork point when `base-ref` is off-branch, instead of dropping it and collapsing to one commit.
