### PR TITLE
RUN-1088 | feat(generate-release-notes): expose start_sha and end_sha

### DIFF
--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -28,6 +28,12 @@ inputs:
     default: "false"
 
 outputs:
+  start_sha:
+    description: "First commit of the release range. Use it as linear-release's base-ref."
+    value: ${{ steps.shas.outputs.start_sha }}
+  end_sha:
+    description: "Last commit of the release range."
+    value: ${{ steps.shas.outputs.end_sha }}
   release_notes:
     description: "Generated release notes (full content of release-notes.md)"
     value: ${{ steps.notes.outputs.release_notes }}


### PR DESCRIPTION
The action already computes the release range in the `shas` step but only returned the rendered notes. Expose `start_sha` / `end_sha` so callers can hand `linear-release` an accurate `base-ref` rather than letting it infer one from the tag graph. RUN-1088.

Outputs only — no behaviour change.
