### PR TITLE
RUN-1088 | feat(linear-release): expose the links input

### DIFF
--- a/linear-release/README.md
+++ b/linear-release/README.md
@@ -41,6 +41,7 @@ jobs:
 | `name` | no | the tag | Overrides the title. Rarely needed |
 | `base-ref` | no | | Start of the commit scan, **exclusive** — the previous release tag, if it exists |
 | `include-paths` | no | | Comma-separated globs restricting which commits count. For monorepos |
+| `links` | no | | Links to attach, one per line: absolute URL or `Label=URL` |
 | `issue-pattern` | no | all odigos team keys | Regex whose first capture group is an issue key, matched against commit subjects |
 | `release-notes` | no | | Path to a markdown file to use as the release notes |
 | `dry-run` | no | `false` | Scan and read, but make no changes in Linear |

--- a/linear-release/action.yml
+++ b/linear-release/action.yml
@@ -67,6 +67,12 @@ inputs:
       you override it.
     required: false
     default: '\b((?:DEVOPS|RUMBA|CORE|PLAT|PRD|RUN|GEN|SEC|DES)-[0-9]+)'
+  links:
+    description: >
+      Links to attach to the release, one per line, each an absolute URL or
+      `Label=URL`. Appended without de-duplication, so a re-run adds them again.
+    required: false
+    default: ""
   release-notes:
     description: >
       Path to a markdown file whose contents become the release notes in
@@ -174,6 +180,7 @@ runs:
         version: ${{ steps.guard.outputs.short-sha != '' && steps.guard.outputs.short-sha || inputs.version }}
         base_ref: ${{ steps.guard.outputs.base-ref }}
         include_paths: ${{ inputs.include-paths }}
+        links: ${{ inputs.links }}
         issue_pattern: ${{ inputs.issue-pattern }}
         release_notes: ${{ steps.guard.outputs.release-notes }}
         dry_run: ${{ inputs.dry-run }}


### PR DESCRIPTION
Forwards the upstream `links` input. Callers pinning the upstream action directly pass links today and would lose them on switching to this wrapper. RUN-1088.

Appended without de-duplication upstream, so a re-run adds them again — noted in the input description.
